### PR TITLE
Simplify MarginAccountActions args getters

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,4 +5,5 @@
   "semi": true,
   "singleQuote": true,
   "jsxSingleQuote": true,
+  "printWidth": 120
 }

--- a/src/connector/MarginAccountActions.ts
+++ b/src/connector/MarginAccountActions.ts
@@ -3,111 +3,125 @@ import { BigNumber, Contract, ContractReceipt, Signer, ethers } from 'ethers';
 
 import BlendPoolAbi from '../assets/abis/AloeBlend.json';
 import Big from 'big.js';
+import JSBI from 'jsbi';
 import { BlendPoolStats } from '../data/BlendPoolDataResolver';
 
 import MarginAccountAbi from '../assets/abis/MarginAccount.json';
 import { ActionCardState, ActionID } from '../data/Actions';
 import { TokenData } from '../data/TokenData';
 
-export async function modifyMarginAccount(
-    actionCardResults: ActionCardState[],
-    token0: TokenData,
-    token1: TokenData,
-    kitty0Address: string,
-    kitty1Address: string,
-    signer: Signer,
-) {
-    const actions: number[] = [];
-    const args: string[] = [];
+function getTransferInActionArgs(token: TokenData, amount: number): string {
+  const address = token.address;
+  const bigAmount = new Big(amount.toFixed(Math.min(token.decimals, 20))).mul(10 ** token.decimals);
 
-    for (const result of actionCardResults) {
-        let address: string;
-        let amount: Big;
+  return ethers.utils.defaultAbiCoder.encode(['address', 'uint256'], [address, bigAmount.toFixed(0)]);
+}
 
-        switch (result.actionId) {
-            case ActionID.TRANSFER_IN:
-                if (!result.aloeResult) continue;
+function getTransferOutActionArgs(token: TokenData, amount: number): string {
+  const address = token.address;
+  const bigAmount = new Big(amount.toFixed(Math.min(token.decimals, 20))).mul(10 ** token.decimals);
 
-                if (result.aloeResult.token0RawDelta) {
-                    address = token0.address;
-                    amount = new Big(result.aloeResult.token0RawDelta.toFixed(6)).mul(10 ** token0.decimals);
-                } else if (result.aloeResult.token1RawDelta) {
-                    address = token1.address;
-                    amount = new Big(result.aloeResult.token1RawDelta.toFixed(6)).mul(10 ** token1.decimals);
-                } else if (result.aloeResult.token0PlusDelta) {
-                    address = kitty0Address;
-                    amount = new Big(result.aloeResult.token0PlusDelta.toFixed(6)).mul(10 ** 18);
-                } else {
-                    address = kitty1Address;
-                    amount = new Big(result.aloeResult.token1PlusDelta!.toFixed(6)).mul(10 ** 18);
-                }
+  return ethers.utils.defaultAbiCoder.encode(['address', 'uint256'], [address, bigAmount.toFixed(0)]);
+}
 
-                actions.push(result.actionId);
-                args.push(ethers.utils.defaultAbiCoder.encode(
-                    ["address", "uint256"],
-                    [address, amount.toFixed(0)]
-                ));
-                break;
+function getMintActionArgs(kitty: TokenData, amount: number): string {
+  const address = kitty.address;
+  const bigAmount = new Big(amount.toFixed(Math.min(kitty.decimals, 20))).mul(10 ** 18);
 
-            case ActionID.TRANSFER_OUT:
-                if (!result.aloeResult) continue;
+  return ethers.utils.defaultAbiCoder.encode(['address', 'uint256'], [address, bigAmount.toFixed(0)]);
+}
 
-                if (result.aloeResult.token0RawDelta) {
-                    address = token0.address;
-                    amount = new Big((-result.aloeResult.token0RawDelta).toFixed(6)).mul(10 ** token0.decimals);
-                } else if (result.aloeResult.token1RawDelta) {
-                    address = token1.address;
-                    amount = new Big((-result.aloeResult.token1RawDelta).toFixed(6)).mul(10 ** token1.decimals);
-                } else if (result.aloeResult.token0PlusDelta) {
-                    address = kitty0Address;
-                    amount = new Big((-result.aloeResult.token0PlusDelta).toFixed(6)).mul(10 ** 18);
-                } else {
-                    address = kitty1Address;
-                    amount = new Big((-result.aloeResult.token1PlusDelta!).toFixed(6)).mul(10 ** 18);
-                }
+function getBurnActionArgs(kitty: TokenData, amount: number): string {
+  const address = kitty.address;
+  const bigAmount = new Big(amount.toFixed(Math.min(kitty.decimals, 20))).mul(10 ** 18);
 
-                actions.push(result.actionId);
-                args.push(ethers.utils.defaultAbiCoder.encode(
-                    ["address", "uint256"],
-                    [address, amount.toFixed(0)]
-                ));
-                break;
-            
-            case ActionID.MINT:
-                if (!result.aloeResult) continue;
+  return ethers.utils.defaultAbiCoder.encode(['address', 'uint256'], [address, bigAmount.toFixed(0)]);
+}
 
-                if (result.aloeResult.token0PlusDelta) {
-                    address = kitty0Address;
-                    amount = new Big(result.aloeResult.token0PlusDelta.toFixed(6)).mul(10 ** 18);
-                } else {
-                    address = kitty1Address;
-                    amount = new Big(result.aloeResult.token1PlusDelta!.toFixed(6)).mul(10 ** 18);
-                }
+function getBorrowActionArgs(token0: TokenData, amount0: number, token1: TokenData, amount1: number): string {
+  const bigAmount0 = new Big(amount0.toFixed(Math.min(token0.decimals, 20))).mul(10 ** token0.decimals);
+  const bigAmount1 = new Big(amount1.toFixed(Math.min(token1.decimals, 20))).mul(10 ** token1.decimals);
 
-                actions.push(result.actionId);
-                args.push(ethers.utils.defaultAbiCoder.encode(
-                    ["address", "uint256"],
-                    [address, amount.toFixed(0)]
-                ));
-                break
+  return ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256'], [bigAmount0.toFixed(0), bigAmount1.toFixed(0)]);
+}
 
-            case ActionID.BURN:
-                if (!result.aloeResult) continue;
+function getRepayActionArgs(token0: TokenData, amount0: number, token1: TokenData, amount1: number): string {
+  const bigAmount0 = new Big(amount0.toFixed(Math.min(token0.decimals, 20))).mul(10 ** token0.decimals);
+  const bigAmount1 = new Big(amount1.toFixed(Math.min(token1.decimals, 20))).mul(10 ** token1.decimals);
 
-                if (result.aloeResult.token0PlusDelta) {
-                    address = kitty0Address;
-                    amount = new Big((-result.aloeResult.token0PlusDelta).toFixed(6)).mul(10 ** 18);
-                } else {
-                    address = kitty1Address;
-                    amount = new Big((-result.aloeResult.token1PlusDelta!).toFixed(6)).mul(10 ** 18);
-                }
+  return ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256'], [bigAmount0.toFixed(0), bigAmount1.toFixed(0)]);
+}
 
-                actions.push(result.actionId);
-                args.push(ethers.utils.defaultAbiCoder.encode(
-                    ["address", "uint256"],
-                    [address, amount.toFixed(0)]
-                ));
-                break
+function getAddLiquidityActionArgs(lower: number, upper: number, liquidity: JSBI): string {
+    return ethers.utils.defaultAbiCoder.encode(['int24', 'int24', 'uint128'], [lower, upper, liquidity.toString(10)]);
+}
+
+export function getActionArgsFor(
+  state: ActionCardState,
+  token0: TokenData,
+  token1: TokenData,
+  kitty0: TokenData,
+  kitty1: TokenData
+): string | null {
+  switch (state.actionId) {
+    case ActionID.TRANSFER_IN:
+      if (state.aloeResult?.token0RawDelta) return getTransferInActionArgs(token0, state.aloeResult.token0RawDelta);
+      if (state.aloeResult?.token1RawDelta) return getTransferInActionArgs(token1, state.aloeResult.token1RawDelta);
+      if (state.aloeResult?.token0PlusDelta) return getTransferInActionArgs(kitty0, state.aloeResult.token0PlusDelta);
+      if (state.aloeResult?.token1PlusDelta) return getTransferInActionArgs(kitty1, state.aloeResult.token1PlusDelta);
+      return null;
+
+    case ActionID.TRANSFER_OUT:
+      if (state.aloeResult?.token0RawDelta) return getTransferOutActionArgs(token0, -state.aloeResult.token0RawDelta);
+      if (state.aloeResult?.token1RawDelta) return getTransferOutActionArgs(token1, -state.aloeResult.token1RawDelta);
+      if (state.aloeResult?.token0PlusDelta) return getTransferOutActionArgs(kitty0, -state.aloeResult.token0PlusDelta);
+      if (state.aloeResult?.token1PlusDelta) return getTransferOutActionArgs(kitty1, -state.aloeResult.token1PlusDelta);
+      return null;
+
+    case ActionID.MINT:
+      if (state.aloeResult?.token0PlusDelta) return getMintActionArgs(kitty0, state.aloeResult.token0PlusDelta);
+      if (state.aloeResult?.token1PlusDelta) return getMintActionArgs(kitty1, state.aloeResult.token1PlusDelta);
+      return null;
+
+    case ActionID.BURN:
+      if (state.aloeResult?.token0PlusDelta) return getBurnActionArgs(kitty0, -state.aloeResult.token0PlusDelta);
+      if (state.aloeResult?.token1PlusDelta) return getBurnActionArgs(kitty1, -state.aloeResult.token1PlusDelta);
+      return null;
+
+    case ActionID.BORROW:
+      if (state.aloeResult?.token0DebtDelta)
+        return getBorrowActionArgs(kitty0, state.aloeResult.token0DebtDelta, kitty1, 0);
+      if (state.aloeResult?.token1DebtDelta)
+        return getBorrowActionArgs(kitty0, 0, kitty1, state.aloeResult.token1DebtDelta);
+      return null;
+
+    case ActionID.REPAY:
+      if (state.aloeResult?.token0DebtDelta)
+        return getRepayActionArgs(kitty0, -state.aloeResult.token0DebtDelta, kitty1, 0);
+      if (state.aloeResult?.token1DebtDelta)
+        return getRepayActionArgs(kitty0, 0, kitty1, -state.aloeResult.token1DebtDelta);
+      return null;
+
+    case ActionID.ADD_LIQUIDITY:
+        if (state.uniswapResult?.uniswapPosition) {
+            const {lowerBound, upperBound, liquidity} = state.uniswapResult.uniswapPosition;
+            if (lowerBound === null || upperBound === null) return null;
+
+            return getAddLiquidityActionArgs(
+                Math.min(lowerBound, upperBound),
+                Math.max(lowerBound, upperBound),
+                liquidity
+            );
         }
-    }
+        return null;
+
+    case ActionID.REMOVE_LIQUIDITY:
+        return null;
+
+    case ActionID.SWAP:
+        return null;
+
+    default:
+        return null
+  }
 }

--- a/src/data/Actions.ts
+++ b/src/data/Actions.ts
@@ -11,6 +11,7 @@ import UniswapRemoveLiquidityActionCard from '../components/borrow/actions/Unisw
 import { DropdownOption } from '../components/common/Dropdown';
 import { FeeTier } from './FeeTier';
 import { TokenData } from './TokenData';
+import JSBI from 'jsbi';
 
 export enum ActionID {
   TRANSFER_IN,
@@ -54,6 +55,7 @@ export type UniswapPosition = {
   amount1: number;
   lowerBound: number | null;
   upperBound: number | null;
+  liquidity: JSBI;
 };
 
 export enum SelectedToken {

--- a/src/pages/BorrowActionsPage.tsx
+++ b/src/pages/BorrowActionsPage.tsx
@@ -26,10 +26,10 @@ import PnLGraph from '../components/graph/PnLGraph';
 import TokenAllocationPieChartWidget from '../components/borrow/TokenAllocationPieChartWidget';
 import ManageAccountWidget from '../components/borrow/ManageAccountWidget';
 import { RESPONSIVE_BREAKPOINT_MD } from '../data/constants/Breakpoints';
-import UniswapAddLiquidityActionCard from '../components/borrow/actions/UniswapAddLiquidityActionCard';
 import TokenChooser from '../components/common/TokenChooser';
 import { sumOfAssetsUsedForUniswapPositions } from '../util/Uniswap';
 import { ReactComponent as LayersIcon } from '../assets/svg/layers.svg';
+import JSBI from 'jsbi';
 
 export type MarginAccountBalances = {
   assets: number;
@@ -271,6 +271,7 @@ export default function BorrowActionsPage() {
         if (existingPositionIndex !== -1) {
           const existingPosition = updatedCumulativeActionResult.uniswapPositions[existingPositionIndex];
           updatedCumulativeActionResult.uniswapPositions[existingPositionIndex] = {
+            liquidity: JSBI.BigInt(0),
             amount0: existingPosition.amount0 + uniswapPosition.amount0,
             amount1: existingPosition.amount1 + uniswapPosition.amount1,
             lowerBound: existingPosition.lowerBound,


### PR DESCRIPTION
Intention here is (for example) for the MintActionCard to call `getMintActionArgs(...)` and include the result in it's `ActionCardState` report. i.e.:

```
onChange({
  actionId: ActionID.MINT,
  textFields: [value],
  actionArgs: getMintActionArgs(selectedToken, parsedValue), // NEW!!
  aloeResult: {
    token0RawDelta: selectedToken === SelectedToken.TOKEN_ZERO ? -parsedValue : undefined,
    token1RawDelta: selectedToken === SelectedToken.TOKEN_ONE ? -parsedValue : undefined,
    token0PlusDelta: selectedToken === SelectedToken.TOKEN_ZERO ? parsedValue : undefined,
    token1PlusDelta: selectedToken === SelectedToken.TOKEN_ONE ? parsedValue : undefined,
    selectedToken: selectedToken,
  },
  uniswapResult: null,
});
```

Alternatively, I wrote a big `getActionArgsFor` function which takes in arbitrary `ActionCardState` and _infers_ the values necessary to get `actionArgs`. This could be used later on (like when the "Confirm" button is clicked) to get action args for all actions in our array, instead of doing stuff in `onChange`. I don't like this organization as much but it's there if we need it.