### PR TITLE
Auto switch network when not on goreli

### DIFF
--- a/src/components/header/ConnectWalletButton.tsx
+++ b/src/components/header/ConnectWalletButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { chain as wagmiChain, useConnect, useDisconnect, useNetwork, useSwitchNetwork } from 'wagmi';
+import { chain, useConnect, useDisconnect, useNetwork, useSwitchNetwork } from 'wagmi';
 
 import { CloseableModal } from '../common/Modal';
 import { formatAddress } from '../../util/FormatAddress';
@@ -26,10 +26,10 @@ export default function ConnectWalletButton(props: ConnectWalletButtonProps) {
   const [shouldAttemptToSwitchNetwork, setShouldAttemptToSwitchNetwork] = useState<boolean>(true);
 
   // MARK: wagmi hooks
-  const { connect, connectors, data: connectionData, error } = useConnect({ chainId: wagmiChain.goerli.id });
-  const { chain } = useNetwork();
+  const { connect, connectors, data: connectionData, error } = useConnect({ chainId: chain.goerli.id });
+  const { chain: currentChain } = useNetwork();
   const { isLoading, switchNetwork } = useSwitchNetwork({
-    chainId: wagmiChain.goerli.id,
+    chainId: chain.goerli.id,
     onError: (error) => {
       setShouldAttemptToSwitchNetwork(false);
     },
@@ -38,10 +38,10 @@ export default function ConnectWalletButton(props: ConnectWalletButtonProps) {
     },
   });
   useEffect(() => {
-    if (!isLoading && chain?.id !== wagmiChain.goerli.id && shouldAttemptToSwitchNetwork) {
-      switchNetwork?.(wagmiChain.goerli.id);
+    if (!isLoading && currentChain?.id !== chain.goerli.id && shouldAttemptToSwitchNetwork) {
+      switchNetwork?.(chain.goerli.id);
     }
-  }, [shouldAttemptToSwitchNetwork, chain, isLoading, switchNetwork]);
+  }, [shouldAttemptToSwitchNetwork, currentChain, isLoading, switchNetwork]);
   const { disconnect } = useDisconnect();
   
   return (

--- a/src/pages/BorrowAccountsPage.tsx
+++ b/src/pages/BorrowAccountsPage.tsx
@@ -61,7 +61,6 @@ async function getMarginAccountsForUser(
 export default function BorrowAccountsPage() {
   // MARK: component state
   // --> transaction modals
-  const network = useNetwork();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showFailedModal, setShowFailedModal] = useState(false);
@@ -72,6 +71,7 @@ export default function BorrowAccountsPage() {
 
   // MARK: wagmi hooks
   const provider = useProvider();
+  const { chain } = useNetwork();
   const { address } = useAccount();
   const { data: signer } = useSigner();
   const marginAccountLensContract = useContract({
@@ -151,7 +151,7 @@ export default function BorrowAccountsPage() {
       mounted = false;
     };
     //TODO: temporary while we need metamask to fetch this info
-  }, [address, marginAccountLensContract, network.chain, provider]);
+  }, [address, marginAccountLensContract, chain, provider]);
 
   return (
     <AppPage>


### PR DESCRIPTION
Instead of prompting the users to swtich to Goreli ourselves, we can use Metamask to do it for us. I did my best to prompt the user whenever possible while still letting them choose to not use Goreli for a specific session if they choose. If you feel you can do the logic better, feel free to take a swing at it, but be sure to thoroughly test as things may not work as you would expect.