### PR TITLE
Adding tooltips to action cards

### DIFF
--- a/src/components/borrow/BaseActionCard.tsx
+++ b/src/components/borrow/BaseActionCard.tsx
@@ -4,6 +4,7 @@ import tw from 'twin.macro';
 import { Display, Text } from '../common/Typography';
 import { ReactComponent as CloseModal } from '../../assets/svg/close_modal.svg';
 import { ActionID, ActionProvider, getNameOfAction } from '../../data/Actions';
+import Tooltip from '../common/Tooltip';
 
 const ActionCardContainer = styled.div.attrs(
   (props: { isCausingError: boolean }) => props
@@ -44,10 +45,11 @@ export type BaseActionCardProps = {
   isCausingError: boolean;
   children: React.ReactNode;
   onRemove: () => void;
+  tooltipContent?: React.ReactNode;
 };
 
 export function BaseActionCard(props: BaseActionCardProps) {
-  const { actionProvider, action, isCausingError, children, onRemove } = props;
+  const { actionProvider, action, isCausingError, children, onRemove, tooltipContent } = props;
   return (
     <ActionCardContainer isCausingError={isCausingError}>
       <div className='w-full flex justify-start items-center gap-4 mb-4'>
@@ -62,6 +64,14 @@ export function BaseActionCard(props: BaseActionCardProps) {
           </SvgWrapper>
           <Display size='S'>{actionProvider.name}</Display>
         </div>
+        {tooltipContent && (
+          <Tooltip
+            buttonSize='M'
+            position='top-center'
+            filled={true}
+            content={tooltipContent}
+          />
+        )}
         <button type='button' title='Remove' className='ml-auto'>
           <SvgWrapper>
             <CloseModal onClick={onRemove} />

--- a/src/components/borrow/actions/AloeAddMarginActionCard.tsx
+++ b/src/components/borrow/actions/AloeAddMarginActionCard.tsx
@@ -5,6 +5,7 @@ import { ActionCardProps, ActionID, ActionProviders, getDropdownOptionFromSelect
 import useEffectOnce from '../../../data/hooks/UseEffectOnce';
 import { getTransferInActionArgs } from '../../../connector/MarginAccountActions';
 import { TokenData } from '../../../data/TokenData';
+import { Text } from '../../common/Typography';
 
 export function AloeAddMarginActionCard(prop: ActionCardProps) {
   const { token0, token1, kitty0, kitty1, previousActionCardState, isCausingError, onRemove, onChange } = prop;
@@ -65,6 +66,7 @@ export function AloeAddMarginActionCard(prop: ActionCardProps) {
       actionProvider={ActionProviders.AloeII}
       isCausingError={isCausingError}
       onRemove={onRemove}
+      tooltipContent={<Text>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Modi omnis quos facere provident, sapiente vero voluptas reiciendis esse eos iusto et accusamus molestias dolorem! Qui dignissimos in provident ullam voluptas?</Text>}
     >
       <div className='w-full flex flex-col gap-4 items-center'>
         <Dropdown

--- a/src/data/Actions.ts
+++ b/src/data/Actions.ts
@@ -88,8 +88,6 @@ export type ActionCardState = {
   actionId: ActionID;
   actionArgs?: string;
   textFields?: string[];
-  error?: boolean;
-  errorMsg?: string;
   aloeResult: AloeResult | null;
   uniswapResult: UniswapResult | null;
 };


### PR DESCRIPTION
Added optional tooltips to action cards that can be added by adding a tooltipContent to the BaseActionCardProps. See an example of this in action below:
![margin-card-tooltip1](https://user-images.githubusercontent.com/17186604/189234568-b118266a-d14d-4325-b97d-dc574e975f47.PNG)
![margin-card-tooltip2](https://user-images.githubusercontent.com/17186604/189234566-26d8a7e6-3010-4dd6-ab21-545c9dde74dd.PNG)
