### PR TITLE
Use block number to re-fetch margin accounts

### DIFF
--- a/src/pages/BorrowAccountsPage.tsx
+++ b/src/pages/BorrowAccountsPage.tsx
@@ -41,7 +41,6 @@ export default function BorrowAccountsPage() {
   const blockNumber = useBlockNumber({
     chainId: currentChainId,
     watch: true,
-    cacheTime: 2000,
   });
   const marginAccountLensContract = useContract({
     addressOrName: '0x2CfDfC4817b0fAf09Fa1613108418D7Ba286725a',
@@ -51,7 +50,6 @@ export default function BorrowAccountsPage() {
 
   useEffect(() => {
     let mounted = true;
-    console.log(blockNumber.data);
 
     async function fetch(userAddress: string) {
       const updatedMarginAccounts = await fetchMarginAccountPreviews(marginAccountLensContract, provider, userAddress);


### PR DESCRIPTION
As the title suggests, I am using useBlockNumber to automatically re-fetch the user's margin accounts each time a new block occurs. I also attempted to fix some bugs relating to the modals.