### PR TITLE
Fixing delay with PnL Graph and fixing ticks

### DIFF
--- a/src/components/graph/PnLGraph.tsx
+++ b/src/components/graph/PnLGraph.tsx
@@ -21,6 +21,7 @@ import {
   priceToSqrtRatio,
   sqrtRatioToPrice,
 } from '../../data/MarginAccount';
+import { GENERAL_DEBOUNCE_DELAY_MS } from '../../pages/BorrowActionsPage';
 import { formatNumberInput } from '../../util/Numbers';
 import { SquareInput } from '../common/Input';
 import { SvgWrapper } from '../common/SvgWrapper';
@@ -30,7 +31,6 @@ import { PnLGraphPlaceholder } from './PnLGraphPlaceholder';
 import PnLGraphTooltip from './tooltips/PnLGraphTooltip';
 
 const SECONDARY_COLOR = 'rgba(130, 160, 182, 1)';
-const GENERAL_DEBOUNCE_DELAY_MS = 750;
 const INPUT_DEBOUNCE_DELAY_MS = 25;
 
 const Wrapper = styled.div`
@@ -280,9 +280,12 @@ export default function PnLGraph(props: PnLGraphProps) {
   const liquidationLower = liquidationThresholds?.lower ?? 0;
   const liquidationUpper = liquidationThresholds?.upper ?? Infinity;
 
+  const closestLowerTickToShow = data[Math.floor((data.length - 1) / 2 - (data.length - 1) / 10)]?.x;
+  const closestUpperTickToShow = data[Math.ceil((data.length - 1) / 2 + (data.length - 1) / 10)]?.x;
+
   const ticks = [price];
-  if (liquidationLower > priceA) ticks.push(liquidationLower);
-  if (liquidationUpper < priceB) ticks.push(liquidationUpper);
+  if (liquidationLower > priceA && liquidationLower < closestLowerTickToShow) ticks.push(liquidationLower);
+  if (liquidationUpper < priceB && liquidationUpper > closestUpperTickToShow) ticks.push(liquidationUpper);
 
   const gradientOffset = () => {
     const dataMax = Math.max(...data.map((i) => i.y));
@@ -341,6 +344,7 @@ export default function PnLGraph(props: PnLGraphProps) {
                   return formatNumberRelativeToSize(value);
                 }}
                 tick={{ fill: SECONDARY_COLOR, fontSize: '14px' }}
+                minTickGap={25}
               />
               <YAxis stroke={SECONDARY_COLOR} fontSize='14px' />
               <ReferenceLine y={0} stroke={SECONDARY_COLOR} />

--- a/src/pages/BorrowActionsPage.tsx
+++ b/src/pages/BorrowActionsPage.tsx
@@ -53,6 +53,7 @@ import { ReactComponent as PieChartIcon } from '../assets/svg/pie_chart.svg';
 import { useDebouncedEffect } from '../data/hooks/UseDebouncedEffect';
 import Big from 'big.js';
 
+export const GENERAL_DEBOUNCE_DELAY_MS = 250;
 const SECONDARY_COLOR = 'rgba(130, 160, 182, 1)';
 
 const BodyWrapper = styled.div`
@@ -425,7 +426,7 @@ export default function BorrowActionsPage() {
       const lt: LiquidationThresholds = computeLiquidationThresholds(displayedMarginAccount, displayedUniswapPositions, 0.025, 120, 6);
       setLiquidationThresholds(lt);
     },
-    200,
+    GENERAL_DEBOUNCE_DELAY_MS,
     [displayedMarginAccount, displayedUniswapPositions]
   );
 


### PR DESCRIPTION
Made it so the PnL graph and liquidation thresholds both use the same delay for debouncing so that their updates happen more in unison. I also made it so that liquidation threshold ticks do not show if they are too close to the current price tick (to avoid overlap). It may not look perfect, but it definitely looks better than overlapping ticks.

Here is an image of what the latter looks like in one scenario:
![pnl_graph_smart_tick](https://user-images.githubusercontent.com/17186604/190868142-4b995ff8-2dec-4553-8ad3-8cb7ad985cd1.PNG)
