### PR TITLE
Watch for new blocks for token balances

### DIFF
--- a/prime/src/components/borrow/ManageAccountWidget.tsx
+++ b/prime/src/components/borrow/ManageAccountWidget.tsx
@@ -260,10 +260,10 @@ export default function ManageAccountWidget(props: ManageAccountWidgetProps) {
     },
   });
   const { address: userAddress } = useAccount();
-  const { data: userBalance0Asset } = useBalance({ addressOrName: userAddress, token: token0.address });
-  const { data: userBalance1Asset } = useBalance({ addressOrName: userAddress, token: token1.address });
-  const { data: userBalance0Kitty } = useBalance({ addressOrName: userAddress, token: kitty0.address });
-  const { data: userBalance1Kitty } = useBalance({ addressOrName: userAddress, token: kitty1.address });
+  const { data: userBalance0Asset } = useBalance({ addressOrName: userAddress, token: token0.address, watch: true });
+  const { data: userBalance1Asset } = useBalance({ addressOrName: userAddress, token: token1.address, watch: true });
+  const { data: userBalance0Kitty } = useBalance({ addressOrName: userAddress, token: kitty0.address, watch: true });
+  const { data: userBalance1Kitty } = useBalance({ addressOrName: userAddress, token: kitty1.address, watch: true });
   const { data: userAllowance0Asset } = useAllowance(token0, userAddress ?? '', MARGIN_ACCOUNT_CALLEE);
   const { data: userAllowance1Asset } = useAllowance(token1, userAddress ?? '', MARGIN_ACCOUNT_CALLEE);
   const { data: userAllowance0Kitty } = useAllowance(kitty0, userAddress ?? '', MARGIN_ACCOUNT_CALLEE);


### PR DESCRIPTION
Addressing the issue where user balances do not update until the user refreshes the page. To fix this, I added the watch argument to the wagmi call. More thought should be put into this down the road to try to minimize the number of calls needed while still providing the user with updates.