### PR TITLE
Factoring out common components from Prime + Earn

### DIFF
--- a/earn/src/components/common/FeeTierContainer.tsx
+++ b/earn/src/components/common/FeeTierContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FeeTier, PrintFeeTier } from '../../data/FeeTier';
-import RoundedBadge from './RoundedBadge';
+import RoundedBadge from 'shared/lib/components/common/RoundedBadge';
 
 export type FeeTierProps = {
   feeTier: FeeTier;

--- a/earn/src/components/lend/LendPairCard.tsx
+++ b/earn/src/components/lend/LendPairCard.tsx
@@ -18,7 +18,7 @@ import {
   CardSubTitleWrapper,
   CardTitleWrapper,
   CardWrapper,
-} from '../common/Card';
+} from 'shared/lib/components/common/Card';
 import tw from 'twin.macro';
 import { ReactComponent as PlusIcon } from '../../assets/svg/plus.svg';
 import { ReactComponent as EditIcon } from '../../assets/svg/edit.svg';

--- a/earn/src/components/lend/LendTokenInfo.tsx
+++ b/earn/src/components/lend/LendTokenInfo.tsx
@@ -1,6 +1,6 @@
 import { TokenData } from '../../data/TokenData';
 import { roundPercentage, formatTokenAmount, formatUSDAuto } from '../../util/Numbers';
-import InfoFigure from '../common/InfoFigure';
+import InfoFigure from 'shared/lib/components/common/InfoFigure';
 
 const FIGURE_COLOR = 'rgba(255, 255, 255, 0.6)';
 

--- a/earn/src/components/lend/YieldAggregatorCard.tsx
+++ b/earn/src/components/lend/YieldAggregatorCard.tsx
@@ -12,7 +12,7 @@ import {
   CardTitleWrapper,
   CardWrapper,
   ValueText,
-} from '../common/Card';
+} from 'shared/lib/components/common/Card';
 import YieldTokenIcons from './YieldTokenIcons';
 import tw from 'twin.macro';
 

--- a/earn/tailwind.config.js
+++ b/earn/tailwind.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   content: [
     './src/**/*.{js,ts,jsx,tsx}',
+    '../shared/src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {

--- a/prime/src/components/borrow/BorrowSelectActionModal.tsx
+++ b/prime/src/components/borrow/BorrowSelectActionModal.tsx
@@ -6,7 +6,7 @@ import { Text, Display } from 'shared/lib/components/common/Typography';
 import { ReactComponent as BackArrowIcon } from '../../assets/svg/back_arrow.svg';
 import { ReactComponent as LayersIcon } from '../../assets/svg/layers.svg';
 import { Action, ActionCardState } from '../../data/Actions';
-import { SvgWrapper } from '../common/SvgWrapper';
+import { SvgWrapper } from 'shared/lib/components/common/SvgWrapper';
 
 const SECONDARY_COLOR = 'rgba(130, 160, 182, 1)';
 const TEMPLATE_COLOR = '#4b6980';

--- a/prime/src/components/borrow/HypotheticalToggleButton.tsx
+++ b/prime/src/components/borrow/HypotheticalToggleButton.tsx
@@ -1,4 +1,4 @@
-import ToggleButton from '../../components/common/ToggleButton';
+import ToggleButton from 'shared/lib/components/common/ToggleButton';
 import { ReactComponent as EyeIcon } from '../../assets/svg/eye.svg';
 import { ReactComponent as EyeOffIcon } from '../../assets/svg/eye-off.svg';
 import styled from 'styled-components';

--- a/prime/src/components/borrow/MarginAccountHeader.tsx
+++ b/prime/src/components/borrow/MarginAccountHeader.tsx
@@ -5,7 +5,7 @@ import { RESPONSIVE_BREAKPOINT_SM, RESPONSIVE_BREAKPOINT_XS } from '../../data/c
 import { TokenData } from '../../data/TokenData';
 import { formatAddressStart } from '../../util/FormatAddress';
 import FeeTierContainer from '../common/FeeTierContainer';
-import RoundedBadge from '../common/RoundedBadge';
+import RoundedBadge from 'shared/lib/components/common/RoundedBadge';
 import { Display } from 'shared/lib/components/common/Typography';
 
 const MarginPairContainer = styled.div`

--- a/prime/src/components/borrow/modal/CreatedMarginAccountModal.tsx
+++ b/prime/src/components/borrow/modal/CreatedMarginAccountModal.tsx
@@ -9,7 +9,7 @@ import {
   MESSAGE_TEXT_COLOR,
   VALUE_TEXT_COLOR,
 } from '../../common/Modal';
-import TokenBreakdown from '../../common/TokenBreakdown';
+import TokenBreakdown from 'shared/lib/components/common/TokenBreakdown';
 import { Text } from 'shared/lib/components/common/Typography';
 import { MODAL_BLACK_TEXT_COLOR } from '../../common/Modal';
 

--- a/prime/src/components/common/FeeTierContainer.tsx
+++ b/prime/src/components/common/FeeTierContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FeeTier, PrintFeeTier } from '../../data/FeeTier';
-import RoundedBadge from './RoundedBadge';
+import RoundedBadge from 'shared/lib/components/common/RoundedBadge';
 
 export type FeeTierProps = {
   feeTier: FeeTier;

--- a/prime/src/components/graph/PnLGraph.tsx
+++ b/prime/src/components/graph/PnLGraph.tsx
@@ -24,7 +24,7 @@ import {
 import { GENERAL_DEBOUNCE_DELAY_MS } from '../../pages/BorrowActionsPage';
 import { formatNumberInput } from '../../util/Numbers';
 import { SquareInput } from '../common/Input';
-import { SvgWrapper } from '../common/SvgWrapper';
+import { SvgWrapper } from 'shared/lib/components/common/SvgWrapper';
 import Tooltip from '../common/Tooltip';
 import { Text } from 'shared/lib/components/common/Typography';
 import { PnLGraphPlaceholder } from './PnLGraphPlaceholder';

--- a/prime/tailwind.config.js
+++ b/prime/tailwind.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   content: [
     './src/**/*.{js,ts,jsx,tsx}',
+    '../shared/src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {

--- a/shared/src/components/common/Card.tsx
+++ b/shared/src/components/common/Card.tsx
@@ -1,0 +1,136 @@
+import styled from 'styled-components';
+import {
+  RESPONSIVE_BREAKPOINT_MD,
+  RESPONSIVE_BREAKPOINT_SM,
+} from '../../data/constants/Breakpoints';
+
+const CARD_BODY_BG_COLOR = 'rgba(13, 23, 30, 1)';
+const TOKEN_ICON_BORDER_COLOR = 'rgba(0, 0, 0, 1)';
+const BODY_DIVIDER_BG_COLOR = 'rgba(255, 255, 255, 0.1)';
+
+export const CardWrapper = styled.div.attrs(
+  (props: { borderGradient: string; shadowColor: string }) => props
+)`
+  display: grid;
+  grid-template-columns: 89fr 159fr;
+  width: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+
+  &:hover {
+    box-shadow: 0px 8px 48px 0px ${(props) => props.shadowColor};
+    &:before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      border-radius: 8px;
+      padding: 1.5px;
+      background: ${(props) => props.borderGradient};
+      -webkit-mask: linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
+      -webkit-mask-composite: xor;
+      mask-composite: exclude;
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const CardTitleWrapper = styled.div.attrs(
+  (props: { backgroundGradient: string }) => props
+)`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 32px;
+  gap: 18px;
+  background: ${(props) => props.backgroundGradient};
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    padding: 32px 16px;
+  }
+`;
+
+export const CardSubTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    flex-direction: column;
+    align-items: start;
+  }
+`;
+
+export const CardBodyWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  background: ${CARD_BODY_BG_COLOR};
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+export const TokenPairTickers = styled.div`
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 32px;
+  font-family: 'ClashDisplay-Variable';
+`;
+
+export const TokenIconsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  margin-right: 0;
+  margin-left: -0.5rem;
+  width: 56px;
+  height: 32px;
+`;
+
+export const TokenIcon = styled.img`
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 1);	
+  position: relative;
+  width: 32px;
+  height: 32px;
+  box-shadow: 0 0 0 3px ${TOKEN_ICON_BORDER_COLOR};
+`;
+
+export const BodySubContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: calc(50% - 0.5px);
+  padding-left: 40px;
+  padding-right: 48px;
+  height: 88px;
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    padding: 20px 32px;
+    height: auto;
+  }
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    width: 100%;
+  }
+`;
+
+export const BodyDivider = styled.div`
+  width: 1px;
+  height: 88px;
+  background-color: ${BODY_DIVIDER_BG_COLOR};
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    width: 100%;
+    height: 1px;
+  }
+`;
+
+export const ValueText = styled.span`
+  font-size: 32px;
+  font-weight: 700;
+`;

--- a/shared/src/components/common/InfoFigure.tsx
+++ b/shared/src/components/common/InfoFigure.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Text } from './Typography';
+
+const DASHED_DIVIDER_BORDER_COLOR = 'rgba(255, 255, 255, 0.6)';
+const SILO_TEXT_COLOR = 'rgba(228, 237, 246, 1)';
+
+const InfoContainer = styled.div.attrs(
+  (props: { shouldGrow: boolean }) => props
+)`
+  display: flex;
+  flex-direction: column;
+  flex-grow: ${(props) => (props.shouldGrow ? 1 : 0)};
+  gap: 8px;
+`;
+
+const InfoItem = styled.div.attrs(
+  (props: { figureColor: string }) => props
+)`
+  display: flex;
+  align-items: center;
+  padding-left: 24px;
+  position: relative;
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0px;
+    top: calc(50% - 4px);
+    width: 8px;
+    height: 8px;
+    border-radius: 100%;
+    background: ${(props) => props.figureColor};
+  }
+  &:first-child::after {
+    content: '';
+    position: absolute;
+    left: 3px;
+    top: 16px;
+    width: 2px;
+    height: 24px;
+    background: ${(props) => props.figureColor};
+  }
+`;
+
+const DashedDivider = styled.div`
+  margin-left: 8px;
+  margin-right: 8px;
+  position: relative;
+  flex-grow: 1;
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: calc(50% - 1px);
+    width: 100%;
+    height: 1px;
+    border-bottom: 1px dashed ${DASHED_DIVIDER_BORDER_COLOR};
+  }
+`;
+
+export type InfoFigureProps = {
+  label0: string;
+  value0: string;
+  label1: string;
+  value1: string;
+  figureColor: string;
+  shouldGrow?: boolean;
+};
+
+export default function InfoFigure(props: InfoFigureProps) {
+  const { label0, value0, label1, value1, figureColor, shouldGrow } = props;
+  return (
+    <InfoContainer shouldGrow={shouldGrow}>
+      <InfoItem figureColor={figureColor}>
+        <Text size='M' weight='medium'>{label0}</Text>
+        <DashedDivider />
+        <Text size='S' weight='medium' color={SILO_TEXT_COLOR}>{value0}</Text>
+      </InfoItem>
+      <InfoItem figureColor={figureColor}>
+        <Text size='M' weight='medium'>{label1}</Text>
+        <DashedDivider />
+        <Text size='S' weight='medium' color={SILO_TEXT_COLOR}>{value1}</Text>
+      </InfoItem>
+    </InfoContainer>
+  );
+}

--- a/shared/src/components/common/PageHeading.tsx
+++ b/shared/src/components/common/PageHeading.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export type PageHeadingProps = {
+  children?: React.ReactNode;
+};
+
+export default function PageHeading(props: PageHeadingProps) {
+  return (
+    <h1 className='py-2 text-2xl text-left text-grey-1000 font-semibold'>
+      {props.children}
+    </h1>
+  );
+}

--- a/shared/src/components/common/RoundedBadge.tsx
+++ b/shared/src/components/common/RoundedBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Text } from './Typography';
+
+const BADGE_TEXT_COLOR = 'rgba(204, 223, 237, 1)';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 100px;
+`;
+
+export type RoundedBadgeProps = {
+  children: React.ReactNode;
+  className?: string;
+  title?: string;
+};
+
+export default function RoundedBadge(props: RoundedBadgeProps) {
+  const { children, className, title } = props;
+  return (
+    <Wrapper className={className}>
+      <Text size='S' weight='medium' color={BADGE_TEXT_COLOR} title={title}>
+        {children}
+      </Text>
+    </Wrapper>
+  );
+}

--- a/shared/src/components/common/Spinner.tsx
+++ b/shared/src/components/common/Spinner.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export const ALT_SPINNER_SIZES = {
+  S: 30,
+  M: 50,
+  L: 70,
+};
+
+export const IOS_STYLE_SPINNER_SIZES = {
+  S: 0.5,
+  M: 0.75,
+  L: 1,
+};
+
+export const AltSpinner = styled.div.attrs(
+  (props: { size?: 'S' | 'M' | 'L' }) => props
+)`
+  --size: ${(props) => ALT_SPINNER_SIZES[props.size || 'L']}px;
+  --offset: ${(props) => ALT_SPINNER_SIZES[props.size || 'L'] / 2}px;
+  position: absolute;
+  width: var(--size);
+  height: var(--size);
+  top: calc(50% - var(--offset));
+  left: calc(50% - var(--offset));
+  border-radius: 50%;
+  border-top: 5px solid #63b59a;
+  border-right: 5px solid transparent;
+  animation: alt-spin 1s linear infinite;
+
+  @keyframes alt-spin {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+const IOSStyleSpinnerWrapper = styled.div.attrs(
+  (props: { size: 'S' | 'M' | 'L' }) => props
+)`
+  span {
+    --translate-y: ${(props) =>
+      `calc(-30px * ${IOS_STYLE_SPINNER_SIZES[props.size]})`};
+    --width: ${(props) => `calc(8px * ${IOS_STYLE_SPINNER_SIZES[props.size]})`};
+    --height: ${(props) =>
+      `calc(20px * ${IOS_STYLE_SPINNER_SIZES[props.size]})`};
+    --offset-left: ${(props) =>
+      `calc(50% - calc(8px / 2 * ${IOS_STYLE_SPINNER_SIZES[props.size]}))`};
+    --offset-top: ${(props) =>
+      `calc(50% - calc(20px / 2 * ${IOS_STYLE_SPINNER_SIZES[props.size]}))`};
+    display: block;
+    position: absolute;
+    left: var(--offset-left);
+    top: var(--offset-top);
+    width: var(--width);
+    height: var(--height);
+    background: #fff;
+    border-radius: 4px;
+
+    &:nth-child(1) {
+      transform: rotate(0deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: 0s;
+    }
+
+    &:nth-child(2) {
+      transform: rotate(30deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -1.1s;
+    }
+
+    &:nth-child(3) {
+      transform: rotate(60deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -1s;
+    }
+
+    &:nth-child(4) {
+      transform: rotate(90deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.9s;
+    }
+
+    &:nth-child(5) {
+      transform: rotate(120deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.8s;
+    }
+
+    &:nth-child(6) {
+      transform: rotate(150deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.7s;
+    }
+
+    &:nth-child(7) {
+      transform: rotate(180deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.6s;
+    }
+
+    &:nth-child(8) {
+      transform: rotate(210deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.5s;
+    }
+
+    &:nth-child(9) {
+      transform: rotate(240deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.4s;
+    }
+
+    &:nth-child(10) {
+      transform: rotate(270deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.3s;
+    }
+
+    &:nth-child(11) {
+      transform: rotate(300deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.2s;
+    }
+
+    &:nth-child(12) {
+      transform: rotate(330deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.1s;
+    }
+  }
+
+  @keyframes spin {
+    0% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 0.25;
+    }
+  }
+`;
+
+export type IOSStyleSpinnerProps = {
+  size?: 'S' | 'M' | 'L';
+};
+
+export function IOSStyleSpinner(props: IOSStyleSpinnerProps) {
+  return (
+    <IOSStyleSpinnerWrapper size={props.size || 'L'}>
+      {Array.from({ length: 12 }).map((_, i) => (
+        <span key={i} />
+      ))}
+    </IOSStyleSpinnerWrapper>
+  );
+}

--- a/shared/src/components/common/SvgWrapper.tsx
+++ b/shared/src/components/common/SvgWrapper.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+export const SvgWrapper = styled.div.attrs(
+  (props: {
+    width?: number;
+    height?: number;
+    svgWidth?: number;
+    svgHeight?: number;
+    padding?: number;
+    fillColor?: string;
+    strokeColor?: string;
+    hoverFillColor?: string;
+    hoverStrokeColor?: string;
+    activeFillColor?: string;
+    activeStrokeColor?: string;
+  }) => props
+)`
+  display: flex;
+  align-items: center; 
+  justify-content: center;
+  ${(props) => props.width && `width: ${props.width}px;`};
+  ${(props) => props.height && `height: ${props.height}px;`};
+  ${(props) => props.padding && `padding: ${props.padding}px;`};
+
+  svg {
+    ${(props) => props.svgWidth && `width: ${props.svgWidth}px;`};
+    ${(props) => props.svgHeight && `height: ${props.svgHeight}px;`};
+    path {
+      ${(props) => props.fillColor && `fill: ${props.fillColor};`};
+      ${(props) => props.strokeColor && `stroke: ${props.strokeColor};`};
+    }
+  }
+
+  &:hover {
+    svg {
+      path {
+        ${(props) => props.hoverFillColor && `fill: ${props.hoverFillColor};`};
+        ${(props) => props.hoverStrokeColor && `stroke: ${props.hoverStrokeColor};`};
+      }
+    }
+  }
+
+  &:active {
+    svg {
+      path {
+        ${(props) => props.activeFillColor && `fill: ${props.activeFillColor};`};
+        ${(props) => props.activeStrokeColor && `stroke: ${props.activeStrokeColor};`};
+      }
+    }
+  }
+`;

--- a/shared/src/components/common/ToggleButton.tsx
+++ b/shared/src/components/common/ToggleButton.tsx
@@ -1,0 +1,28 @@
+import { ReactChild } from "react";
+import styled from "styled-components";
+
+const LabelWrapper = styled.label`
+  user-select: none;
+  cursor: pointer;
+`;
+
+const HiddenInput = styled.input`
+  display: none;
+`;
+
+export type ToggleButtonProps = {
+  children: ReactChild;
+  isActive: boolean;
+  setIsActive: (isActive: boolean) => void;
+  desc?: string;
+};
+
+export default function ToggleButton(props: ToggleButtonProps) {
+  const { children, isActive, setIsActive, desc } = props;
+  return (
+    <LabelWrapper>
+      {children}
+      <HiddenInput type='checkbox' title={desc || 'toggle'} checked={isActive} onChange={() => setIsActive(!isActive)} />
+    </LabelWrapper>
+  )
+}

--- a/shared/src/components/common/TokenBreakdown.tsx
+++ b/shared/src/components/common/TokenBreakdown.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Text } from './Typography';
+
+const LABEL_TEXT_COLOR = 'rgba(75, 105, 128, 1)';
+const VALUE_TEXT_COLOR = 'rgba(255, 255, 255, 1)';
+
+const TokenBreakdownWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  column-gap: 0.75rem;
+  padding: 16px;
+  border: 1px solid rgba(26, 41, 52, 1);
+  border-radius: 8px;
+`;
+
+export type TokenBreakdownProps = {
+  token0Ticker: string;
+  token1Ticker: string;
+  token0Estimate: string;
+  token1Estimate: string;
+};
+
+export default function TokenBreakdown(props: TokenBreakdownProps) {
+  const { token0Ticker, token1Ticker, token0Estimate, token1Estimate } = props;
+  return (
+    <div className='w-full grid grid-cols-2 gap-x-2'>
+      <TokenBreakdownWrapper>
+        <Text size='XS' weight='medium' color={LABEL_TEXT_COLOR}>
+          {token0Ticker}
+        </Text>
+        <Text
+          size='M'
+          weight='medium'
+          color={VALUE_TEXT_COLOR}
+          title={token0Estimate}
+          className='overflow-hidden text-ellipsis whitespace-nowrap'
+        >
+          {token0Estimate}
+        </Text>
+      </TokenBreakdownWrapper>
+      <TokenBreakdownWrapper>
+        <Text size='XS' weight='medium' color={LABEL_TEXT_COLOR}>
+          {token1Ticker}
+        </Text>
+        <Text
+          size='M'
+          weight='medium'
+          color={VALUE_TEXT_COLOR}
+          title={token1Estimate}
+          className='overflow-hidden text-ellipsis whitespace-nowrap'
+        >
+          {token1Estimate}
+        </Text>
+      </TokenBreakdownWrapper>
+    </div>
+  );
+}

--- a/shared/src/components/common/WidgetHeading.tsx
+++ b/shared/src/components/common/WidgetHeading.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Text } from './Typography';
+
+export type WidgetHeadingProps = {
+  children?: React.ReactNode;
+};
+
+export default function WidgetHeading(props: WidgetHeadingProps) {
+  return (
+    <Text size='L' weight='medium' color='rgba(255, 255, 255, 1)' className='flex items-center gap-x-2'>
+      {props.children}
+    </Text>
+  );
+}


### PR DESCRIPTION
Components factored out:
- `RoundedBadge`
- `Card`
- `InfoFigure`
- `PageHeading`
- `Spinner`
- `WidgetHeading`
- `SvgWrapper`
- `TokenBreakdown`
- `ToggleButton`

**Note**: Attempted to delete component `WideAppPage.tsx` (as part of this PR) from `prime` and `earn` directories but was unable to do so because styling got messed up on these pages when I deleted the file. Will look into this and diagnose, but wanted to share my finding.