### PR TITLE
Add auto refresh when user acks successful modal

### DIFF
--- a/earn/src/components/lend/LendPairCard.tsx
+++ b/earn/src/components/lend/LendPairCard.tsx
@@ -201,12 +201,6 @@ export default function LendPairCard(props: LendingPair & {hasDeposited0: boolea
         setOpen={(open: boolean) => {
           setIsEditToken0PositionModalOpen(open);
         }}
-        onConfirm={() => {
-          setIsEditToken0PositionModalOpen(false);
-        }}
-        onCancel={() => {
-          setIsEditToken0PositionModalOpen(false);
-        }}
       />
       <EditPositionModal
         token={token1}
@@ -214,12 +208,6 @@ export default function LendPairCard(props: LendingPair & {hasDeposited0: boolea
         open={isEditToken1PositionModalOpen}
         setOpen={(open: boolean) => {
           setIsEditToken1PositionModalOpen(open);
-        }}
-        onConfirm={() => {
-          setIsEditToken1PositionModalOpen(false);
-        }}
-        onCancel={() => {
-          setIsEditToken1PositionModalOpen(false);
         }}
       />
     </div>


### PR DESCRIPTION
#99 
When the user successfully deposits/withdraws from the Earn page, they are greeted with a success modal. Previously, when the user either clicked "Okay" or closed the modal by clicking the "X" or outside of the modal, we did not do anything to refresh the user's balance data, as seen at the top of the screen. This PR aims to refresh the data whenever the user clicks "Okay," "X," or outside the success modal by refreshing the page.

I also got rid of the `onConfirm` and `onCancel` callbacks as they are no longer relevant, given the direction we took with the EditPositionModal component.