### PR TITLE
Make UI aware of whether user has already claimed fees for a Uni pos

### DIFF
--- a/prime/src/components/borrow/ManageAccountWidget.tsx
+++ b/prime/src/components/borrow/ManageAccountWidget.tsx
@@ -152,6 +152,7 @@ export default function ManageAccountWidget(props: ManageAccountWidgetProps) {
       amount0Kitty: 0,
       amount1Kitty: 0,
     },
+    claimedFeeUniswapKeys: [],
   };
 
   useEffect(() => {

--- a/prime/src/components/borrow/actions/UniswapAddLiquidityActionCard.tsx
+++ b/prime/src/components/borrow/actions/UniswapAddLiquidityActionCard.tsx
@@ -53,7 +53,7 @@ function fromFields(fields: string[] | undefined): PreviousState {
 }
 
 export default function UniswapAddLiquidityActionCard(props: ActionCardProps) {
-  const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onChange, onRemove } = props;
+  const { marginAccount, accountState, userInputFields, isCausingError, onChange, onRemove } = props;
   const { token0, token1, feeTier } = marginAccount;
 
   // MARK: state for user inputs

--- a/prime/src/components/borrow/actions/UniswapClaimFeesActionCard.tsx
+++ b/prime/src/components/borrow/actions/UniswapClaimFeesActionCard.tsx
@@ -23,17 +23,19 @@ const SVGIconWrapper = styled.div.attrs((props: { width: number; height: number 
 `;
 
 export default function UnsiwapClaimFeesActionCard(props: ActionCardProps) {
-  const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onChange, onRemove } = props;
+  const { marginAccount, accountState, userInputFields, isCausingError, onChange, onRemove } = props;
   const { token0, token1 } = marginAccount;
-  const { uniswapPositions } = accountState;
+  const { uniswapPositions, claimedFeeUniswapKeys } = accountState;
 
-  const dropdownOptions = uniswapPositions.map((lp, index) => {
-    return {
-      label: `Lower: ${lp.lower} Upper: ${lp.upper}`,
-      value: index.toString(),
-      isDefault: index === 0,
-    } as DropdownOption;
-  });
+  const dropdownOptions = uniswapPositions
+    .filter((lp) => !claimedFeeUniswapKeys.includes(uniswapPositionKey(marginAccount.address, lp.lower, lp.upper)))
+    .map((lp, index) => {
+      return {
+        label: `Lower: ${lp.lower} Upper: ${lp.upper}`,
+        value: index.toString(),
+        isDefault: index === 0,
+      } as DropdownOption;
+    });
 
   let selectedOption: DropdownOption | undefined = undefined;
 

--- a/prime/src/components/borrow/actions/UniswapRemoveLiquidityActionCard.tsx
+++ b/prime/src/components/borrow/actions/UniswapRemoveLiquidityActionCard.tsx
@@ -30,7 +30,7 @@ const SVGIconWrapper = styled.div.attrs((props: { width: number; height: number 
 //TODO: make sure the numbers displayed are accurate and contain enough digits
 //TODO: potentially allow for more digits in the percentage input
 export default function UniswapRemoveLiquidityActionCard(props: ActionCardProps) {
-  const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onChange, onRemove } = props;
+  const { marginAccount, accountState, userInputFields, isCausingError, onChange, onRemove } = props;
   const { token0, token1 } = marginAccount;
   const { uniswapPositions } = accountState;
 

--- a/prime/src/data/actions/ActionOperators.ts
+++ b/prime/src/data/actions/ActionOperators.ts
@@ -129,6 +129,7 @@ export function removeLiquidityOperator(
 ): AccountState | null {
   const assets = { ...operand.assets };
   const uniswapPositions = operand.uniswapPositions.concat();
+  const claimedFeeUniswapKeys = operand.claimedFeeUniswapKeys.concat();
 
   const [amount0, amount1] = getAmountsForLiquidity(
     liquidity,
@@ -159,6 +160,8 @@ export function removeLiquidityOperator(
   }
   oldPosition.liquidity = JSBI.subtract(oldPosition.liquidity, liquidity);
   uniswapPositions[idx] = oldPosition;
+  claimedFeeUniswapKeys.push(key);
 
-  return { ...operand, assets, uniswapPositions };
+  // eslint-disable-next-line object-curly-newline
+  return { ...operand, assets, uniswapPositions, claimedFeeUniswapKeys };
 }

--- a/prime/src/data/actions/Actions.ts
+++ b/prime/src/data/actions/Actions.ts
@@ -38,6 +38,7 @@ export interface AccountState {
   readonly uniswapPositions: readonly UniswapPosition[];
   readonly availableBalances: UserBalances;
   readonly requiredAllowances: UserBalances;
+  readonly claimedFeeUniswapKeys: readonly string[];
 }
 
 type Operator = (state: AccountState) => AccountState | null;


### PR DESCRIPTION
This eliminates the possibility of a user accidentally claiming fees multiple times for a given position. Doing so would have no effect under the hood, so we might as well disable it in the UI.

Kinda shows off what the refactor enables / makes-easier