### PR TITLE
Adding association between pie chart and balance/apy

### DIFF
--- a/earn/src/components/portfolio/PortfolioMetrics.tsx
+++ b/earn/src/components/portfolio/PortfolioMetrics.tsx
@@ -52,6 +52,7 @@ export default function PortfolioMetrics(props: PortfolioMetricsProps) {
     apySum = activeBalances[activeIndex].apy;
     apy = apySum;
   }
+  const isHoveringOverSlice = activeIndex >= 0;
   return (
     <>
       <PieChartContainer>
@@ -62,7 +63,7 @@ export default function PortfolioMetrics(props: PortfolioMetricsProps) {
           token={activeAsset}
         />
       </PieChartContainer>
-      <BalanceContainer>
+      <BalanceContainer className={isHoveringOverSlice ? 'active' : ''}>
         <Text size='M' weight='bold' color='rgba(130, 160, 182, 1)'>
           Balance
         </Text>
@@ -75,7 +76,7 @@ export default function PortfolioMetrics(props: PortfolioMetricsProps) {
           </Display>
         </div>
       </BalanceContainer>
-      <APYContainer>
+      <APYContainer className={isHoveringOverSlice ? 'active' : ''}>
         <Text size='M' weight='bold' color='rgba(130, 160, 182, 1)'>
           APY
         </Text>


### PR DESCRIPTION
Added a line between the pie chart and the balance/apy when the user hovers over a slice on the earn portfolio page. Below is an image of this in action:
![earn-piechart-balance-apy](https://user-images.githubusercontent.com/17186604/205478312-0db41ac3-1e9e-402a-8092-6d4be5ad28c8.PNG)
