### PR TITLE
Improving performance of pnl graph by limiting data set

### DIFF
--- a/prime/src/components/graph/PnLGraph.tsx
+++ b/prime/src/components/graph/PnLGraph.tsx
@@ -275,7 +275,6 @@ export default function PnLGraph(props: PnLGraphProps) {
   useDebouncedEffect(
     () => {
       const updatedData = calculateGraphData();
-      console.log('updatedData', updatedData);
       setData(updatedData);
       setLocalInTermsOfToken0(inTermsOfToken0);
     },


### PR DESCRIPTION
Finally, adding the performance optimization to the borrowing page involves lowering the number of data points we calculate and display on the PNL graph. Decreasing the number of points from 365 to 74 vastly improves performance without causing any visual difference in appearance. Additionally, I am fixing the tooltip, which was being outlined at all times.