### PR TITLE
Fixing withdraw for markets page

### DIFF
--- a/earn/src/components/lend/modal/content/WithdrawModalContent.tsx
+++ b/earn/src/components/lend/modal/content/WithdrawModalContent.tsx
@@ -1,17 +1,17 @@
-import { ReactElement, useContext, useState } from 'react';
+import { ReactElement, useContext, useEffect, useMemo, useState } from 'react';
 
 import { SendTransactionResult } from '@wagmi/core';
-import { BigNumber } from 'ethers';
+import Big from 'big.js';
+import { BigNumber, ethers } from 'ethers';
 import { FilledStylizedButtonWithIcon } from 'shared/lib/components/common/Buttons';
 import { Text } from 'shared/lib/components/common/Typography';
-import { useAccount, useContractWrite } from 'wagmi';
+import { useAccount, useContractRead, useContractWrite } from 'wagmi';
 
 import { ChainContext } from '../../../../App';
 import KittyABI from '../../../../assets/abis/Kitty.json';
 import { ReactComponent as AlertTriangleIcon } from '../../../../assets/svg/alert_triangle.svg';
 import { ReactComponent as CheckIcon } from '../../../../assets/svg/check_black.svg';
 import { ReactComponent as MoreIcon } from '../../../../assets/svg/more_ellipses.svg';
-import { useAmountToShares } from '../../../../data/hooks/UseAmountToShares';
 import { useBalanceOfUnderlying } from '../../../../data/hooks/UseUnderlyingBalanceOf';
 import { Kitty } from '../../../../data/Kitty';
 import { Token } from '../../../../data/Token';
@@ -48,10 +48,103 @@ function getConfirmButton(
   }
 }
 
+type WithdrawButtonProps = {
+  withdrawAmount: string;
+  maxWithdrawBalance: string;
+  maxRedeemBalance: string;
+  token: Token;
+  kitty: Kitty;
+  accountAddress: string;
+  setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
+};
+
+function WithdrawButton(props: WithdrawButtonProps) {
+  const { withdrawAmount, maxWithdrawBalance, maxRedeemBalance, token, kitty, accountAddress, setPendingTxn } = props;
+  const { activeChain } = useContext(ChainContext);
+  const [isPending, setIsPending] = useState(false);
+
+  const { data: requestedShares, isLoading: convertToSharesIsLoading } = useContractRead({
+    address: kitty.address,
+    abi: KittyABI,
+    functionName: 'convertToShares',
+    args: [ethers.utils.parseUnits(withdrawAmount || '0.00', token.decimals).toString()],
+    chainId: activeChain.id,
+  });
+
+  const {
+    write: contractWrite,
+    isSuccess: contractDidSucceed,
+    isLoading: contractIsLoading,
+    data: contractData,
+  } = useContractWrite({
+    address: kitty.address,
+    abi: KittyABI,
+    mode: 'recklesslyUnprepared',
+    functionName: 'redeem',
+    chainId: activeChain.id,
+  });
+
+  useEffect(() => {
+    if (contractDidSucceed && contractData) {
+      setPendingTxn(contractData);
+      setIsPending(false);
+    } else if (!contractIsLoading && !contractDidSucceed) {
+      setIsPending(false);
+    }
+  }, [contractDidSucceed, contractData, contractIsLoading, setPendingTxn]);
+
+  const numericDepositBalance = Number(maxWithdrawBalance) || 0;
+  const numericDepositAmount = Number(withdrawAmount) || 0;
+
+  let confirmButtonState = ConfirmButtonState.READY;
+
+  if (numericDepositAmount > numericDepositBalance) {
+    confirmButtonState = ConfirmButtonState.INSUFFICIENT_KITTY;
+  } else if (isPending || convertToSharesIsLoading) {
+    confirmButtonState = ConfirmButtonState.PENDING;
+  }
+
+  const confirmButton = getConfirmButton(confirmButtonState, token, kitty);
+
+  function handleClickConfirm() {
+    if (confirmButtonState === ConfirmButtonState.READY && requestedShares) {
+      setIsPending(true);
+      const numericRequestedShares = BigNumber.from(requestedShares.toString());
+      const numericMaxRedeemBalance = BigNumber.from(maxRedeemBalance);
+      // Being extra careful here to make sure we don't withdraw more than the user has
+      const finalWithdrawAmount = numericRequestedShares.gt(numericMaxRedeemBalance)
+        ? numericMaxRedeemBalance
+        : numericRequestedShares;
+      contractWrite?.({
+        recklesslySetUnpreparedArgs: [finalWithdrawAmount.toString(), accountAddress, accountAddress],
+        recklesslySetUnpreparedOverrides: { gasLimit: BigNumber.from('600000') },
+      });
+    }
+  }
+
+  const isDepositAmountValid = numericDepositAmount > 0;
+  const shouldConfirmButtonBeDisabled = !(confirmButton.enabled && isDepositAmountValid);
+
+  return (
+    <FilledStylizedButtonWithIcon
+      size='M'
+      fillWidth={true}
+      color={MODAL_BLACK_TEXT_COLOR}
+      onClick={handleClickConfirm}
+      Icon={confirmButton.Icon}
+      position='trailing'
+      svgColorType='stroke'
+      disabled={shouldConfirmButtonBeDisabled}
+    >
+      {confirmButton.text}
+    </FilledStylizedButtonWithIcon>
+  );
+}
+
 export type WithdrawModalContentProps = {
   token: Token;
   kitty: Kitty;
-  setPendingTxnResult: (result: SendTransactionResult) => void;
+  setPendingTxnResult: (result: SendTransactionResult | null) => void;
 };
 
 export default function WithdrawModalContent(props: WithdrawModalContentProps) {
@@ -59,58 +152,37 @@ export default function WithdrawModalContent(props: WithdrawModalContentProps) {
   const { activeChain } = useContext(ChainContext);
 
   const [withdrawAmount, setWithdrawAmount] = useState('');
-  const [isPending, setIsPending] = useState(false);
 
   const { address: accountAddress } = useAccount();
 
-  const contract = useContractWrite({
+  const { data: maxWithdraw } = useContractRead({
     address: kitty.address,
     abi: KittyABI,
-    mode: 'recklesslyUnprepared',
-    functionName: 'withdraw',
+    functionName: 'maxWithdraw',
     chainId: activeChain.id,
+    args: [accountAddress] as const,
+    watch: true,
   });
 
-  const balanceOfUnderlying = useBalanceOfUnderlying(token, kitty, accountAddress || '');
-  const amountToShares = useAmountToShares(token, kitty, withdrawAmount);
+  const { data: maxRedeem } = useContractRead({
+    address: kitty.address,
+    abi: KittyABI,
+    functionName: 'maxRedeem',
+    chainId: activeChain.id,
+    args: [accountAddress] as const,
+    watch: true,
+  });
 
-  const sharesToWithdraw = amountToShares ?? '0';
-  const underlyingBalance = balanceOfUnderlying ?? '0';
-
-  const numericWithdrawAmount = Number(withdrawAmount) || 0;
-  const numericWithdrawBalance = parseFloat(underlyingBalance);
-
-  let confirmButtonState = ConfirmButtonState.READY;
-
-  if (numericWithdrawAmount > numericWithdrawBalance) {
-    confirmButtonState = ConfirmButtonState.INSUFFICIENT_KITTY;
-  } else if (isPending) {
-    confirmButtonState = ConfirmButtonState.PENDING;
-  }
-
-  const confirmButton = getConfirmButton(confirmButtonState, token, kitty);
-
-  function handleClickConfirm() {
-    // TODO: Do not use setStates in async functions outside of useEffect
-    switch (confirmButtonState) {
-      case ConfirmButtonState.READY:
-        setIsPending(true);
-        contract
-          .writeAsync?.({
-            recklesslySetUnpreparedArgs: [sharesToWithdraw],
-            recklesslySetUnpreparedOverrides: { gasLimit: BigNumber.from('600000') },
-          })
-          .then((txnResult) => {
-            setPendingTxnResult(txnResult);
-          })
-          .catch((error) => {
-            setIsPending(false);
-          });
-        break;
-      default:
-        break;
+  const maxWithdrawBalance = useMemo(() => {
+    if (maxWithdraw) {
+      return new Big(maxWithdraw.toString()).div(10 ** token.decimals).toString();
     }
-  }
+    return '0.00';
+  }, [maxWithdraw, token.decimals]);
+
+  const balanceOfUnderlying = useBalanceOfUnderlying(token, kitty, accountAddress || '');
+
+  const underlyingBalance = balanceOfUnderlying ?? '0';
 
   return (
     <>
@@ -135,18 +207,15 @@ export default function WithdrawModalContent(props: WithdrawModalContentProps) {
         </Text>
       </div>
       <div className='w-max ml-auto'>
-        <FilledStylizedButtonWithIcon
-          size='M'
-          fillWidth={true}
-          color={MODAL_BLACK_TEXT_COLOR}
-          onClick={handleClickConfirm}
-          Icon={confirmButton.Icon}
-          position='trailing'
-          svgColorType='stroke'
-          disabled={!confirmButton.enabled || numericWithdrawAmount === 0}
-        >
-          {confirmButton.text}
-        </FilledStylizedButtonWithIcon>
+        <WithdrawButton
+          accountAddress={accountAddress || '0x'}
+          token={token}
+          kitty={kitty}
+          withdrawAmount={withdrawAmount}
+          maxRedeemBalance={maxRedeem ? maxRedeem.toString() : '0'}
+          maxWithdrawBalance={maxWithdrawBalance}
+          setPendingTxn={setPendingTxnResult}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
As the title suggests, this PR fixes the withdraw functionality for the markets page using the latest contracts. Additionally, I took this opportunity to begin to utilize the newer patterns used in the portfolio modals to increase cohesion across the codebase.