### PR TITLE
Adding util for getting the corresponding etherscan link for a chain

### DIFF
--- a/earn/src/components/lend/modal/PendingTxnModal.tsx
+++ b/earn/src/components/lend/modal/PendingTxnModal.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { Text } from 'shared/lib/components/common/Typography';
+import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
 
+import { ChainContext } from '../../../App';
 import { LoadingModal, MESSAGE_TEXT_COLOR } from '../../common/Modal';
 
 export type PendingTxnModalProps = {
@@ -11,6 +13,7 @@ export type PendingTxnModalProps = {
 };
 
 export default function PendingTxnModal(props: PendingTxnModalProps) {
+  const { activeChain } = useContext(ChainContext);
   return (
     <LoadingModal open={props.open} setOpen={props.setOpen} title='Submitting Order'>
       <Text size='M' weight='medium' color={MESSAGE_TEXT_COLOR}>
@@ -19,7 +22,7 @@ export default function PendingTxnModal(props: PendingTxnModalProps) {
       {props.txnHash && (
         <Text size='M' weight='medium' color={MESSAGE_TEXT_COLOR}>
           <a
-            href={`https://goerli.etherscan.io/tx/${props.txnHash}`}
+            href={`${getEtherscanUrlForChain(activeChain)}/tx/${props.txnHash}`}
             target='_blank'
             rel='noopener noreferrer'
             className='underline'

--- a/earn/src/components/lend/modal/content/SuccessModalContent.tsx
+++ b/earn/src/components/lend/modal/content/SuccessModalContent.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { FilledStylizedButton } from 'shared/lib/components/common/Buttons';
 import { Text } from 'shared/lib/components/common/Typography';
+import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
 
+import { ChainContext } from '../../../../App';
 import SuccessIcon from '../../../../assets/svg/success.svg';
 import { HorizontalDivider, MESSAGE_TEXT_COLOR } from '../../../common/Modal';
 import { MODAL_BLACK_TEXT_COLOR } from '../../../common/Modal';
@@ -16,6 +18,7 @@ export type SuccessModalContentProps = {
 
 export default function SuccessModalContent(props: SuccessModalContentProps) {
   const { confirmationType, txnHash, onConfirm } = props;
+  const { activeChain } = useContext(ChainContext);
 
   return (
     <div>
@@ -29,7 +32,7 @@ export default function SuccessModalContent(props: SuccessModalContentProps) {
         </Text>
         <Text>
           <a
-            href={`https://goerli.etherscan.io/tx/${txnHash}`}
+            href={`${getEtherscanUrlForChain(activeChain)}/tx/${txnHash}`}
             target='_blank'
             rel='noopener noreferrer'
             className='underline'

--- a/prime/src/components/borrow/modal/PendingTxnModal.tsx
+++ b/prime/src/components/borrow/modal/PendingTxnModal.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { Text } from 'shared/lib/components/common/Typography';
+import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
 
+import { ChainContext } from '../../../App';
 import { LoadingModal, MESSAGE_TEXT_COLOR } from '../../common/Modal';
 
 export type PendingTxnModalProps = {
@@ -11,6 +13,7 @@ export type PendingTxnModalProps = {
 };
 
 export default function PendingTxnModal(props: PendingTxnModalProps) {
+  const { activeChain } = useContext(ChainContext);
   return (
     <LoadingModal open={props.open} setOpen={props.setOpen} title='Submitting Order'>
       <Text size='M' weight='medium' color={MESSAGE_TEXT_COLOR}>
@@ -19,7 +22,7 @@ export default function PendingTxnModal(props: PendingTxnModalProps) {
       {props.txnHash && (
         <Text size='M' weight='medium' color={MESSAGE_TEXT_COLOR}>
           <a
-            href={`https://goerli.etherscan.io/tx/${props.txnHash}`}
+            href={`${getEtherscanUrlForChain(activeChain)}/tx/${props.txnHash}`}
             target='_blank'
             rel='noopener noreferrer'
             className='underline'

--- a/shared/src/data/constants/Values.ts
+++ b/shared/src/data/constants/Values.ts
@@ -1,3 +1,4 @@
 import { chain } from 'wagmi';
 
 export const DEFAULT_CHAIN = chain.goerli;
+export const DEFAULT_ETHERSCAN_URL = 'https://etherscan.io';

--- a/shared/src/util/Chains.ts
+++ b/shared/src/util/Chains.ts
@@ -1,0 +1,11 @@
+import { Chain } from 'wagmi';
+import { DEFAULT_ETHERSCAN_URL } from '../data/constants/Values';
+
+/**
+ * Get the Etherscan url for a given chain
+ * @param chain the chain to get the Etherscan url for
+ * @returns the Etherscan url for the given chain
+ */
+export function getEtherscanUrlForChain(chain: Chain): string {
+  return chain.blockExplorers?.etherscan?.url ?? DEFAULT_ETHERSCAN_URL;
+}


### PR DESCRIPTION
As the title suggests, I added a utility for retrieving the respective Etherscan URL for a given chain. I decide to use a util method despite the fact that the underlying logic is quite simple to avoid needless code reuse and imports.