### PR TITLE
Only show active chains

### DIFF
--- a/shared/src/data/constants/Chains.tsx
+++ b/shared/src/data/constants/Chains.tsx
@@ -2,7 +2,7 @@ import { chain } from 'wagmi';
 
 import { ArbitrumLogo, EthereumLogo, OptimismLogo } from '../../assets/svg/chains';
 
-export const SUPPORTED_CHAINS = [chain.mainnet, chain.goerli, chain.optimism, chain.arbitrum];
+export const SUPPORTED_CHAINS = [chain.goerli, chain.optimism];
 
 export const CHAIN_LOGOS = {
   [chain.mainnet.id]: <EthereumLogo width={16} height={16} />,


### PR DESCRIPTION
As the title suggests, I added logic to only show chains that have aloe-ii contracts deployed on, which as of now is goerli but will soon also include optimism. Below is an image of the updated component:
![activechains](https://user-images.githubusercontent.com/17186604/209867108-212c0e84-b674-4dcc-b833-2d80047ec6a6.PNG)
