### PR TITLE
Adding filter functionality and empty state

### DIFF
--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -183,3 +183,16 @@ export async function getLendingPairBalances(
     kitty1Balance,
   };
 }
+
+/**
+ * Filter lending pairs by tokens
+ * @param lendingPairs Lending pairs
+ * @param tokens Tokens
+ * @returns Filtered lending pairs that contain at least one of the tokens
+ */
+
+export function filterLendingPairsByTokens(lendingPairs: LendingPair[], tokens: Token[]): LendingPair[] {
+  return lendingPairs.filter((pair) => {
+    return tokens.some((token) => token.address === pair.token0.address || token.address === pair.token1.address);
+  });
+}

--- a/earn/src/pages/LendPage.tsx
+++ b/earn/src/pages/LendPage.tsx
@@ -23,6 +23,7 @@ import WelcomeModal from '../components/lend/modal/WelcomeModal';
 import { RESPONSIVE_BREAKPOINT_XS } from '../data/constants/Breakpoints';
 import { API_PRICE_RELAY_LATEST_URL } from '../data/constants/Values';
 import {
+  filterLendingPairsByTokens,
   getAvailableLendingPairs,
   getLendingPairBalances,
   LendingPair,
@@ -284,11 +285,10 @@ export default function LendPage() {
   }, [kittyBalances, totalKittyBalanceUSD]);
 
   const filteredLendingPairs = useMemo(() => {
-    return lendingPairs.filter((pair) => {
-      return selectedOptions.some(
-        (option) => option.value.address === pair.token0.address || option.value.address === pair.token1.address
-      );
-    });
+    return filterLendingPairsByTokens(
+      lendingPairs,
+      selectedOptions.map((o) => o.value)
+    );
   }, [lendingPairs, selectedOptions]);
 
   return (


### PR DESCRIPTION
As the title suggests, I am adding functionality to the filter on the markets page as well as an empty state for when there are no matching lending pairs. This addition is long overdue, but as the saying goes, better late than never :).
![no-lending-pairs-found](https://user-images.githubusercontent.com/17186604/210918495-18d55686-7687-436b-acfb-c99ab3c97d54.PNG)
