### PR TITLE
Adding logic to limit the number of decimals for token

### DIFF
--- a/earn/src/components/portfolio/modal/EarnInterestModal.tsx
+++ b/earn/src/components/portfolio/modal/EarnInterestModal.tsx
@@ -19,7 +19,7 @@ import useAllowanceWrite from '../../../data/hooks/UseAllowanceWrite';
 import { Kitty } from '../../../data/Kitty';
 import { LendingPair } from '../../../data/LendingPair';
 import { Token } from '../../../data/Token';
-import { formatNumberInput, roundPercentage, toBig } from '../../../util/Numbers';
+import { formatNumberInput, roundPercentage, toBig, truncateDecimals } from '../../../util/Numbers';
 import PairDropdown from '../../common/PairDropdown';
 import Tooltip from '../../common/Tooltip';
 import TokenAmountSelectInput from '../TokenAmountSelectInput';
@@ -271,7 +271,8 @@ export default function EarnInterestModal(props: EarnInterestModalProps) {
             onChange={(value) => {
               const output = formatNumberInput(value);
               if (output != null) {
-                setInputValue(output);
+                const truncatedOutput = truncateDecimals(output, selectedOption.decimals);
+                setInputValue(truncatedOutput);
               }
             }}
             options={options}

--- a/earn/src/components/portfolio/modal/SendCryptoModal.tsx
+++ b/earn/src/components/portfolio/modal/SendCryptoModal.tsx
@@ -15,7 +15,7 @@ import { ReactComponent as AlertTriangleIcon } from '../../../assets/svg/alert_t
 import { ReactComponent as CheckIcon } from '../../../assets/svg/check_black.svg';
 import { ReactComponent as MoreIcon } from '../../../assets/svg/more_ellipses.svg';
 import { Token } from '../../../data/Token';
-import { formatNumberInput, String1E } from '../../../util/Numbers';
+import { formatNumberInput, String1E, truncateDecimals } from '../../../util/Numbers';
 import TokenAmountSelectInput from '../TokenAmountSelectInput';
 
 const SECONDARY_COLOR = '#CCDFED';
@@ -243,7 +243,8 @@ export default function SendCryptoModal(props: SendCryptoModalProps) {
             onChange={(value) => {
               const output = formatNumberInput(value);
               if (output != null) {
-                setSendAmountInputValue(output);
+                const truncatedOutput = truncateDecimals(output, selectedOption.decimals);
+                setSendAmountInputValue(truncatedOutput);
               }
             }}
             options={options}

--- a/earn/src/components/portfolio/modal/WithdrawModal.tsx
+++ b/earn/src/components/portfolio/modal/WithdrawModal.tsx
@@ -17,7 +17,7 @@ import { ReactComponent as MoreIcon } from '../../../assets/svg/more_ellipses.sv
 import { Kitty } from '../../../data/Kitty';
 import { LendingPair } from '../../../data/LendingPair';
 import { Token } from '../../../data/Token';
-import { formatNumberInput } from '../../../util/Numbers';
+import { formatNumberInput, truncateDecimals } from '../../../util/Numbers';
 import PairDropdown from '../../common/PairDropdown';
 import Tooltip from '../../common/Tooltip';
 import TokenAmountSelectInput from '../TokenAmountSelectInput';
@@ -281,7 +281,8 @@ export default function WithdrawModal(props: WithdrawModalProps) {
             onChange={(value) => {
               const output = formatNumberInput(value);
               if (output != null) {
-                setInputValue(output);
+                const truncatedOutput = truncateDecimals(output, selectedOption.decimals);
+                setInputValue(truncatedOutput);
               }
             }}
           />

--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -76,7 +76,7 @@ export function roundPercentage(percentage: number, precision?: number): number 
 }
 
 //TODO: refactor this to handle edge cases better
-export function formatNumberInput(input: string, negative?: boolean): string | null {
+export function formatNumberInput(input: string, negative?: boolean, maxDecimals?: number): string | null {
   if (input === '' || input === '-') {
     return '';
   } else if (input === '.') {
@@ -188,4 +188,20 @@ export function formatPriceRatio(x: number, sigDigs = 4): string {
 
 export function areWithinNSigDigs(a: Big, b: Big, n: number): boolean {
   return a.prec(n).eq(b.prec(n));
+}
+
+export function truncateDecimals(value: string, decimals: number): string {
+  const decimalIndex = value.indexOf('.');
+  if (decimalIndex === -1) {
+    return value;
+  }
+  return value.slice(0, decimalIndex + decimals + 1);
+}
+
+export function getDecimalPlaces(value: string): number {
+  const decimalIndex = value.indexOf('.');
+  if (decimalIndex === -1) {
+    return 0;
+  }
+  return value.length - decimalIndex - 1;
 }


### PR DESCRIPTION
As the title suggests, I added logic to ensure the user can't input more decimal places than the selected token allows. This change not only improves UX, but also fixes a bug that caused the withdraw modal to error out if too many decimals were entered.