### PR TITLE
Revamping the prime account page

### DIFF
--- a/prime/src/components/borrow/ActiveMarginAccounts.tsx
+++ b/prime/src/components/borrow/ActiveMarginAccounts.tsx
@@ -1,0 +1,23 @@
+import { Text } from 'shared/lib/components/common/Typography';
+
+import { MarginAccountPreview } from '../../data/MarginAccount';
+import { MarginAccountCard } from './MarginAccountCard';
+
+export type ActiveMarginAccountsProps = {
+  marginAccounts: MarginAccountPreview[];
+};
+
+export default function ActiveMarginAccounts(props: ActiveMarginAccountsProps) {
+  const { marginAccounts } = props;
+  return (
+    <div className='flex items-center justify-start flex-wrap gap-4'>
+      {marginAccounts.length > 0 ? (
+        marginAccounts.map((marginAccount, index) => <MarginAccountCard key={index} {...marginAccount} />)
+      ) : (
+        <Text size='M' weight='bold'>
+          Looks like you don't have any active margin accounts. Click the button above to create one.
+        </Text>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
As the title suggests, I am doing long-awaited updates to the account page, which include adding a loader (basic loader for now) and adding an empty state. Below is an image of the updated component:
![new-account-simple](https://user-images.githubusercontent.com/17186604/212114750-3a3d727d-c1fc-4f08-b401-8ef4f9c45de7.PNG)
