### PR TITLE
Switching from hash router to browser router

### DIFF
--- a/earn/src/index.tsx
+++ b/earn/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ReactDOM from 'react-dom';
 import './index.css';
-import { HashRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from './App';
 

--- a/prime/src/index.tsx
+++ b/prime/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ReactDOM from 'react-dom';
 import './index.css';
-import { HashRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from './App';
 


### PR DESCRIPTION
As the title suggests, I am switching which router we use from HashRouter to BrowserRouter. The initial router choice was from before my time here, so I am unsure if there are any reasons behind using HashRouter over BrowserRouter. The main reason I am opting to switch is that it enables us to remove the pesky '#' from our URLs.