### PR TITLE
Making prices on earn more precise

### DIFF
--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -35,7 +35,7 @@ export function formatUSD(amount: number | null, placeholder = '-'): string {
   if (amount === null) {
     return placeholder;
   }
-  if (amount < 0.01) {
+  if (amount < 0.1) {
     return amount.toLocaleString('en-US', {
       style: 'currency',
       currency: 'USD',


### PR DESCRIPTION
I realized that for prices below $0.01, we just display zero. I added logic to show 2 significant digits for values less than $0.10. As a result, we allow asset prices to be shown as follows:
<img width="300" alt="Screenshot 2023-01-24 at 12 45 10 AM" src="https://user-images.githubusercontent.com/17186604/214221073-8e3f5c6e-42f7-4f23-b40c-bfbcebaae778.png">
