### PR TITLE
Fixing hypothetical positions not displaying

### DIFF
--- a/prime/src/pages/BorrowActionsPage.tsx
+++ b/prime/src/pages/BorrowActionsPage.tsx
@@ -546,7 +546,7 @@ export default function BorrowActionsPage() {
           <Text size='L' weight='medium'>
             Uniswap Positions
           </Text>
-          {uniswapPositions.length === 0 ? (
+          {displayedUniswapPositions.length === 0 ? (
             <EmptyStateWrapper>
               <EmptyStateContainer>
                 <EmptyStateSvgWrapper>


### PR DESCRIPTION
As the title suggests, fixing a one-line bug that caused hypothetical uniswap positions not to display if the user did not have any existing uniswap positions.