### PR TITLE
Adding health bar to actions page

### DIFF
--- a/prime/src/components/borrow/HealthBar.tsx
+++ b/prime/src/components/borrow/HealthBar.tsx
@@ -1,0 +1,55 @@
+import { Display } from 'shared/lib/components/common/Typography';
+import styled from 'styled-components';
+
+const MAX_HEALTH = 3;
+const MIN_HEALTH = 0.5;
+
+const HealthBarContainer = styled.div`
+  width: 100%;
+  height: 32px;
+  background: rgb(235, 87, 87);
+  background: linear-gradient(
+    90deg,
+    rgba(235, 87, 87, 1) 0%,
+    rgba(235, 87, 87, 1) 20%,
+    rgba(242, 201, 76, 1) 23%,
+    rgba(0, 193, 67, 1) 70%,
+    rgba(0, 193, 67, 1) 100%
+  );
+  border-radius: 8px;
+  position: relative;
+`;
+
+const HealthBarDial = styled.div.attrs((props: { healthPercent: number }) => props)`
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 10px 10px 0 10px;
+  border-color: #ffffff transparent transparent transparent;
+  position: absolute;
+  left: ${(props) => props.healthPercent}%;
+  transform: translateX(-50%);
+  top: -4.325px;
+`;
+
+export type HealthBarProps = {
+  health: number;
+};
+
+export default function HealthBar(props: HealthBarProps) {
+  const { health } = props;
+  // Bound health between MIN_HEALTH and MAX_HEALTH
+  const healthPercent =
+    ((Math.max(Math.min(health, MAX_HEALTH), MIN_HEALTH) - MIN_HEALTH) / (MAX_HEALTH - MIN_HEALTH)) * 100;
+  const healthLabel = health > MAX_HEALTH ? `${MAX_HEALTH}+` : health.toFixed(2);
+  return (
+    <div className='w-full flex flex-col align-middle mt-[-24px]'>
+      <Display size='L' weight='medium' className='text-center'>
+        {healthLabel}
+      </Display>
+      <HealthBarContainer>
+        <HealthBarDial healthPercent={healthPercent} />
+      </HealthBarContainer>
+    </div>
+  );
+}

--- a/prime/src/components/common/Tooltip.tsx
+++ b/prime/src/components/common/Tooltip.tsx
@@ -62,7 +62,7 @@ const TooltipContainer = styled.div.attrs(
     }
   }}
   padding: 16px;
-  z-index: 30;
+  z-index: 6;
   border-radius: 8px;
   width: 240px;
   background-color: ${(props) => (props.filled ? 'rgba(26, 41, 52, 1);' : 'rgba(7, 14, 18, 1);')};

--- a/prime/src/pages/BorrowActionsPage.tsx
+++ b/prime/src/pages/BorrowActionsPage.tsx
@@ -19,12 +19,14 @@ import { ReactComponent as InboxIcon } from '../assets/svg/inbox.svg';
 import { ReactComponent as PieChartIcon } from '../assets/svg/pie_chart.svg';
 import { ReactComponent as TrendingUpIcon } from '../assets/svg/trending_up.svg';
 import { AccountStatsCard } from '../components/borrow/AccountStatsCard';
+import HealthBar from '../components/borrow/HealthBar';
 import { HypotheticalToggleButton } from '../components/borrow/HypotheticalToggleButton';
 import ManageAccountWidget from '../components/borrow/ManageAccountWidget';
 import MarginAccountHeader from '../components/borrow/MarginAccountHeader';
 import TokenAllocationPieChartWidget from '../components/borrow/TokenAllocationPieChartWidget';
 import UniswapPositionTable from '../components/borrow/uniswap/UniswapPositionsTable';
 import TokenChooser from '../components/common/TokenChooser';
+import Tooltip from '../components/common/Tooltip';
 import PnLGraph from '../components/graph/PnLGraph';
 import { AccountState, UniswapPosition, UniswapPositionPrior } from '../data/actions/Actions';
 import { ALOE_II_BORROWER_LENS_ADDRESS, ALOE_II_LENDER_LENS_ADDRESS } from '../data/constants/Addresses';
@@ -474,6 +476,8 @@ export default function BorrowActionsPage() {
   const selectedTokenTicker = selectedToken?.ticker || '';
   const unselectedTokenTicker = unselectedToken?.ticker || '';
 
+  console.log(displayedMarginAccount.health);
+
   return (
     <BodyWrapper>
       <HeaderBarContainer>
@@ -494,6 +498,21 @@ export default function BorrowActionsPage() {
         />
       </GridExpandingDiv>
       <div className='w-full flex flex-col justify-between'>
+        <div className='w-full flex flex-col gap-4 mb-8'>
+          <div className='flex gap-2 items-center'>
+            <Text size='L' weight='medium'>
+              Account Health
+            </Text>
+            <Tooltip
+              buttonSize='M'
+              content={`Health is a measure of how close your account is to being liquidated.
+              It is calculated by dividing your account's assets by its liabilities.
+              If your health is at or below 1.0, your account may be liquidated.`}
+              position='top-center'
+            />
+          </div>
+          <HealthBar health={displayedMarginAccount.health} />
+        </div>
         <div className='w-full flex flex-col gap-4 mb-8'>
           <div className='flex gap-4 items-center'>
             <Text size='L' weight='medium'>


### PR DESCRIPTION
As the title suggests, I am adding a health bar to the actions page that outlines the health of the open account. This health bar is from 0.5 to 3, with numbers outside those ranges equal to their corresponding maxes. Below is an image of the new component:
<img width="589" alt="Screenshot 2023-01-31 at 9 22 53 PM" src="https://user-images.githubusercontent.com/17186604/215930013-09831628-77b8-4424-901e-951d3e84431d.png">
