### PR TITLE
Moving the health bar to the manage account widget

### DIFF
--- a/prime/src/components/borrow/HealthBar.tsx
+++ b/prime/src/components/borrow/HealthBar.tsx
@@ -1,5 +1,7 @@
-import { Display } from 'shared/lib/components/common/Typography';
+import { Display, Text } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
+
+import Tooltip from '../common/Tooltip';
 
 const MAX_HEALTH = 3;
 const MIN_HEALTH = 0.5;
@@ -43,10 +45,22 @@ export default function HealthBar(props: HealthBarProps) {
     ((Math.max(Math.min(health, MAX_HEALTH), MIN_HEALTH) - MIN_HEALTH) / (MAX_HEALTH - MIN_HEALTH)) * 100;
   const healthLabel = health > MAX_HEALTH ? `${MAX_HEALTH}+` : health.toFixed(2);
   return (
-    <div className='w-full flex flex-col align-middle mt-[-24px]'>
-      <Display size='L' weight='medium' className='text-center'>
-        {healthLabel}
-      </Display>
+    <div className='w-full flex flex-col align-middle mb-8 mt-8'>
+      <div className='flex gap-2 items-center mb-4'>
+        <Tooltip
+          buttonSize='M'
+          content={`Health is a measure of how close your account is to being liquidated.
+              It is calculated by dividing your account's assets by its liabilities.
+              If your health is at or below 1.0, your account may be liquidated.`}
+          position='top-center'
+        />
+        <Text size='L' weight='medium'>
+          Account Health:
+        </Text>
+        <Display size='M' weight='medium' className='text-center'>
+          {healthLabel}
+        </Display>
+      </div>
       <HealthBarContainer>
         <HealthBarDial healthPercent={healthPercent} />
       </HealthBarContainer>

--- a/prime/src/components/borrow/ManageAccountWidget.tsx
+++ b/prime/src/components/borrow/ManageAccountWidget.tsx
@@ -19,6 +19,7 @@ import { RESPONSIVE_BREAKPOINT_SM, RESPONSIVE_BREAKPOINT_XS } from '../../data/c
 import { MarginAccount } from '../../data/MarginAccount';
 import { UserBalances } from '../../data/UserBalances';
 import BorrowSelectActionModal from './BorrowSelectActionModal';
+import HealthBar from './HealthBar';
 import { ManageAccountTransactionButton } from './ManageAccountTransactionButton';
 
 const Wrapper = styled.div`
@@ -112,11 +113,13 @@ export type ManageAccountWidgetProps = {
   uniswapPositions: readonly UniswapPosition[];
   updateHypotheticalState: (state: AccountState | null) => void;
   onAddFirstAction: () => void;
+  hypotheticalMarginAccount: MarginAccount;
 };
 
 export default function ManageAccountWidget(props: ManageAccountWidgetProps) {
   // MARK: component props
-  const { marginAccount, uniswapPositions, updateHypotheticalState, onAddFirstAction } = props;
+  const { marginAccount, uniswapPositions, updateHypotheticalState, onAddFirstAction, hypotheticalMarginAccount } =
+    props;
   const { address: accountAddress, token0, token1 } = marginAccount;
 
   const { activeChain } = useContext(ChainContext);
@@ -260,6 +263,7 @@ export default function ManageAccountWidget(props: ManageAccountWidgetProps) {
             </ActionCardWrapper>
           </ActionItem>
         </ActionsList>
+        <HealthBar health={hypotheticalMarginAccount?.health || marginAccount.health} />
         <div className='flex justify-end gap-4 mt-4'>
           <ManageAccountTransactionButton
             userAddress={userAddress}

--- a/prime/src/pages/BorrowActionsPage.tsx
+++ b/prime/src/pages/BorrowActionsPage.tsx
@@ -19,14 +19,12 @@ import { ReactComponent as InboxIcon } from '../assets/svg/inbox.svg';
 import { ReactComponent as PieChartIcon } from '../assets/svg/pie_chart.svg';
 import { ReactComponent as TrendingUpIcon } from '../assets/svg/trending_up.svg';
 import { AccountStatsCard } from '../components/borrow/AccountStatsCard';
-import HealthBar from '../components/borrow/HealthBar';
 import { HypotheticalToggleButton } from '../components/borrow/HypotheticalToggleButton';
 import ManageAccountWidget from '../components/borrow/ManageAccountWidget';
 import MarginAccountHeader from '../components/borrow/MarginAccountHeader';
 import TokenAllocationPieChartWidget from '../components/borrow/TokenAllocationPieChartWidget';
 import UniswapPositionTable from '../components/borrow/uniswap/UniswapPositionsTable';
 import TokenChooser from '../components/common/TokenChooser';
-import Tooltip from '../components/common/Tooltip';
 import PnLGraph from '../components/graph/PnLGraph';
 import { AccountState, UniswapPosition, UniswapPositionPrior } from '../data/actions/Actions';
 import { ALOE_II_BORROWER_LENS_ADDRESS, ALOE_II_LENDER_LENS_ADDRESS } from '../data/constants/Addresses';
@@ -487,24 +485,10 @@ export default function BorrowActionsPage() {
           uniswapPositions={uniswapPositions}
           updateHypotheticalState={updateHypotheticalState}
           onAddFirstAction={() => setUserWantsHypothetical(true)}
+          hypotheticalMarginAccount={displayedMarginAccount}
         />
       </GridExpandingDiv>
       <div className='w-full flex flex-col justify-between'>
-        <div className='w-full flex flex-col gap-4 mb-8'>
-          <div className='flex gap-2 items-center'>
-            <Text size='L' weight='medium'>
-              Account Health
-            </Text>
-            <Tooltip
-              buttonSize='M'
-              content={`Health is a measure of how close your account is to being liquidated.
-              It is calculated by dividing your account's assets by its liabilities.
-              If your health is at or below 1.0, your account may be liquidated.`}
-              position='top-center'
-            />
-          </div>
-          <HealthBar health={displayedMarginAccount.health} />
-        </div>
         <div className='w-full flex flex-col gap-4 mb-8'>
           <div className='flex gap-4 items-center'>
             <Text size='L' weight='medium'>


### PR DESCRIPTION
As the title suggests, to provide a better UX, we decided to move the health bar to where the actions are being added so the user can more easily see what their health is while adding actions.
<img width="434" alt="Screenshot 2023-02-04 at 8 02 43 PM" src="https://user-images.githubusercontent.com/17186604/216796263-9412e503-2952-4ec4-826a-f86b5f9345b9.png">
