### PR TITLE
Don't pass hypothetical account into ManageAccountWidget

### DIFF
--- a/prime/src/components/borrow/actions/AloeBorrowActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeBorrowActionCard.tsx
@@ -63,13 +63,13 @@ export function AloeBorrowActionCard(prop: ActionCardProps) {
   });
 
   const [allowed0, allowed1] = maxBorrows(
-    {
-      ...marginAccount,
-      assets: accountState.assets,
-      liabilities: accountState.liabilities,
-    },
+    accountState.assets,
+    accountState.liabilities,
     accountState.uniswapPositions,
-    marginAccount.sqrtPriceX96
+    marginAccount.sqrtPriceX96,
+    marginAccount.iv,
+    token0.decimals,
+    token1.decimals
   );
   const available0 = marketInfo.lender0AvailableAssets.div(10 ** marginAccount.token0.decimals).toNumber();
   const available1 = marketInfo.lender1AvailableAssets.div(10 ** marginAccount.token1.decimals).toNumber();

--- a/prime/src/components/graph/PnLGraph.tsx
+++ b/prime/src/components/graph/PnLGraph.tsx
@@ -80,7 +80,15 @@ function calculatePnL1(
   initialValue = 0
 ): number {
   const sqrtPriceX96 = priceToSqrtRatio(price, marginAccount.token0.decimals, marginAccount.token1.decimals);
-  const assets = getAssets(marginAccount, uniswapPositions, sqrtPriceX96, sqrtPriceX96, sqrtPriceX96);
+  const assets = getAssets(
+    marginAccount.assets,
+    uniswapPositions,
+    sqrtPriceX96,
+    sqrtPriceX96,
+    sqrtPriceX96,
+    marginAccount.token0.decimals,
+    marginAccount.token1.decimals
+  );
   return (
     (assets.fixed0 + assets.fluid0C) * price +
     assets.fixed1 +
@@ -97,7 +105,15 @@ function calculatePnL0(
 ): number {
   const invertedPrice = 1 / price;
   const sqrtPriceX96 = priceToSqrtRatio(invertedPrice, marginAccount.token0.decimals, marginAccount.token1.decimals);
-  const assets = getAssets(marginAccount, uniswapPositions, sqrtPriceX96, sqrtPriceX96, sqrtPriceX96);
+  const assets = getAssets(
+    marginAccount.assets,
+    uniswapPositions,
+    sqrtPriceX96,
+    sqrtPriceX96,
+    sqrtPriceX96,
+    marginAccount.token0.decimals,
+    marginAccount.token1.decimals
+  );
   return (
     (assets.fixed1 + assets.fluid1C) * price +
     assets.fixed0 +

--- a/prime/src/computeLiquidationThresholdsWorker.ts
+++ b/prime/src/computeLiquidationThresholdsWorker.ts
@@ -12,7 +12,17 @@ self.onmessage = (e: MessageEvent<ComputeLiquidationThresholdsRequest>) => {
     const { marginAccountParams, uniswapPositionParams, iterations, precision } = request;
     const marginAccount = parseMarginAccountParams(marginAccountParams);
     const uniswapPositions = parseUniswapPositionParams(uniswapPositionParams);
-    const liquidationThresholds = computeLiquidationThresholds(marginAccount, uniswapPositions, iterations, precision);
+    const liquidationThresholds = computeLiquidationThresholds(
+      marginAccount.assets,
+      marginAccount.liabilities,
+      uniswapPositions,
+      marginAccount.sqrtPriceX96,
+      marginAccount.iv,
+      marginAccount.token0.decimals,
+      marginAccount.token1.decimals,
+      iterations,
+      precision
+    );
     self.postMessage(JSON.stringify(liquidationThresholds));
   } catch (e) {
     console.error(e);

--- a/prime/src/data/actions/Utils.ts
+++ b/prime/src/data/actions/Utils.ts
@@ -31,12 +31,15 @@ export function runWithChecks(
   //       actions, the code singles that one out as problematic. In reality solvency is *also* still an issue,
   //       but to the user it looks like they've fixed solvency by entering bogus data in a single action.
   // TLDR: It's simpler to check solvency inside this for loop
-  const updatedMarginAccount = {
-    ...marginAccount,
+  const solvency = isSolvent(
     assets,
     liabilities,
-  };
-  const solvency = isSolvent(updatedMarginAccount, uniswapPositions, marginAccount.sqrtPriceX96);
+    uniswapPositions,
+    marginAccount.sqrtPriceX96,
+    marginAccount.iv,
+    marginAccount.token0.decimals,
+    marginAccount.token1.decimals
+  );
   if (!solvency.atA || !solvency.atB) {
     console.log('Margin Account not solvent!');
     console.log(solvency);

--- a/prime/src/pages/BorrowActionsPage.tsx
+++ b/prime/src/pages/BorrowActionsPage.tsx
@@ -464,7 +464,15 @@ export default function BorrowActionsPage() {
   const selectedTokenTicker = selectedToken?.ticker || '';
   const unselectedTokenTicker = unselectedToken?.ticker || '';
 
-  const { health } = isSolvent(displayedMarginAccount, displayedUniswapPositions, displayedMarginAccount.sqrtPriceX96);
+  const { health } = isSolvent(
+    displayedMarginAccount.assets,
+    displayedMarginAccount.liabilities,
+    displayedUniswapPositions,
+    displayedMarginAccount.sqrtPriceX96,
+    displayedMarginAccount.iv,
+    token0.decimals,
+    token1.decimals
+  );
   displayedMarginAccount.health = health;
 
   const isShowingHypothetical = userWantsHypothetical && hypotheticalState !== null;
@@ -487,7 +495,6 @@ export default function BorrowActionsPage() {
           uniswapPositions={uniswapPositions}
           updateHypotheticalState={updateHypotheticalState}
           onAddFirstAction={() => setUserWantsHypothetical(true)}
-          hypotheticalMarginAccount={displayedMarginAccount}
         />
       </GridExpandingDiv>
       <div className='w-full flex flex-col justify-between'>


### PR DESCRIPTION
Last week, when we moved the health bar into the ManageAccountWidget, we also passed in the hypothetical margin account in order to compute health. I refactored the arguments for isSolvent (and related funcs) so that it's easier to avoid passing in a marginAccount. We now have everything we need to compute health in the ManageAccountWidget