### PR TITLE
Adding total borrows

### DIFF
--- a/earn/src/components/borrow/GlobalStatsTable.tsx
+++ b/earn/src/components/borrow/GlobalStatsTable.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { RESPONSIVE_BREAKPOINT_XS } from '../../data/constants/Breakpoints';
 import { MarginAccountPreview, MarketInfo } from '../../data/MarginAccount';
-import { roundPercentage } from '../../util/Numbers';
+import { formatTokenAmount, roundPercentage } from '../../util/Numbers';
 
 const STAT_LABEL_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 const STAT_VALUE_TEXT_COLOR = 'rgba(255, 255, 255, 1)';
@@ -59,6 +59,8 @@ export default function GlobalStatsTable(props: GlobalStatsTableProps) {
   const { token0, token1 } = marginAccountPreview;
   const lender0TotalSupply = marketInfo.lender0TotalSupply.div(10 ** token0.decimals);
   const lender1TotalSupply = marketInfo.lender1TotalSupply.div(10 ** token1.decimals);
+  const lender0TotalBorrows = marketInfo.lender0TotalBorrows.div(10 ** token0.decimals);
+  const lender1TotalBorrows = marketInfo.lender1TotalBorrows.div(10 ** token1.decimals);
   return (
     <Wrapper>
       <Text size='M'>Pair Stats</Text>
@@ -68,7 +70,7 @@ export default function GlobalStatsTable(props: GlobalStatsTableProps) {
             {token0.ticker} Total Supply
           </Text>
           <Display size='S' color={STAT_VALUE_TEXT_COLOR}>
-            {lender0TotalSupply.toFixed(2)}
+            {formatTokenAmount(lender0TotalSupply.toNumber(), 4)}
           </Display>
         </StatContainer>
         <StatContainer>
@@ -76,7 +78,7 @@ export default function GlobalStatsTable(props: GlobalStatsTableProps) {
             {token1.ticker} Total Supply
           </Text>
           <Display size='S' color={STAT_VALUE_TEXT_COLOR}>
-            {lender1TotalSupply.toFixed(2)}
+            {formatTokenAmount(lender1TotalSupply.toNumber(), 4)}
           </Display>
         </StatContainer>
         <StatContainer>
@@ -84,7 +86,7 @@ export default function GlobalStatsTable(props: GlobalStatsTableProps) {
             {token0.ticker} Borrows
           </Text>
           <Display size='S' color={STAT_VALUE_TEXT_COLOR}>
-            TODO
+            {formatTokenAmount(lender0TotalBorrows.toNumber(), 4)}
           </Display>
         </StatContainer>
         <StatContainer>
@@ -92,7 +94,7 @@ export default function GlobalStatsTable(props: GlobalStatsTableProps) {
             {token1.ticker} Borrows
           </Text>
           <Display size='S' color={STAT_VALUE_TEXT_COLOR}>
-            TODO
+            {formatTokenAmount(lender1TotalBorrows.toNumber(), 4)}
           </Display>
         </StatContainer>
         <StatContainer>

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -64,6 +64,8 @@ export type MarketInfo = {
   lender1Utilization: number;
   lender0TotalSupply: Big;
   lender1TotalSupply: Big;
+  lender0TotalBorrows: Big;
+  lender1TotalBorrows: Big;
 };
 
 export type LiquidationThresholds = {
@@ -196,6 +198,8 @@ export async function fetchMarketInfoFor(
   const lender1Utilization = new Big(lender1Basics.utilization.toString()).div(10 ** 18).toNumber();
   const lender0TotalSupply = new Big(lender0Basics.totalSupply.toString());
   const lender1TotalSupply = new Big(lender1Basics.totalSupply.toString());
+  const lender0TotalBorrows = new Big(lender0Basics.totalBorrows.toString());
+  const lender1TotalBorrows = new Big(lender1Basics.totalBorrows.toString());
   return {
     lender0,
     lender1,
@@ -205,6 +209,8 @@ export async function fetchMarketInfoFor(
     lender1Utilization: lender1Utilization,
     lender0TotalSupply: lender0TotalSupply,
     lender1TotalSupply: lender1TotalSupply,
+    lender0TotalBorrows: lender0TotalBorrows,
+    lender1TotalBorrows: lender1TotalBorrows,
   };
 }
 


### PR DESCRIPTION
As the title suggests, I am adding total borrows to the pair stats (previously marked as TODO). Additionally, I also updated how we display token amounts in the grid to use four significant digits.