### PR TITLE
Adding the rest of the modals to the earn borrow page

### DIFF
--- a/earn/src/components/borrow/ManageAccountButtons.tsx
+++ b/earn/src/components/borrow/ManageAccountButtons.tsx
@@ -2,13 +2,21 @@ import { OutlinedWhiteButtonWithIcon } from 'shared/lib/components/common/Button
 
 import { ReactComponent as PlusIcon } from '../../assets/svg/plus.svg';
 
-export default function ManageAccountButtons() {
+export type ManageAccountButtonsProps = {
+  onAddCollateral: () => void;
+  onRemoveCollateral: () => void;
+  onBorrow: () => void;
+  onRepay: () => void;
+};
+
+export default function ManageAccountButtons(props: ManageAccountButtonsProps) {
+  const { onAddCollateral, onRemoveCollateral, onBorrow, onRepay } = props;
   return (
     <div className='flex flex-col gap-2 w-max'>
       <OutlinedWhiteButtonWithIcon
         Icon={<PlusIcon />}
         position='leading'
-        onClick={() => {}}
+        onClick={onAddCollateral}
         size='S'
         svgColorType='stroke'
       >
@@ -17,7 +25,7 @@ export default function ManageAccountButtons() {
       <OutlinedWhiteButtonWithIcon
         Icon={<PlusIcon />}
         position='leading'
-        onClick={() => {}}
+        onClick={onRemoveCollateral}
         size='S'
         svgColorType='stroke'
       >
@@ -26,7 +34,7 @@ export default function ManageAccountButtons() {
       <OutlinedWhiteButtonWithIcon
         Icon={<PlusIcon />}
         position='leading'
-        onClick={() => {}}
+        onClick={onBorrow}
         size='S'
         svgColorType='stroke'
       >
@@ -35,7 +43,7 @@ export default function ManageAccountButtons() {
       <OutlinedWhiteButtonWithIcon
         Icon={<PlusIcon />}
         position='leading'
-        onClick={() => {}}
+        onClick={onRepay}
         size='S'
         svgColorType='stroke'
       >

--- a/earn/src/components/borrow/modal/AddCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/AddCollateralModal.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react';
+
+import { SendTransactionResult } from '@wagmi/core';
+import Modal from 'shared/lib/components/common/Modal';
+import { Text } from 'shared/lib/components/common/Typography';
+import { useAccount } from 'wagmi';
+
+import { MarginAccount, MarketInfo } from '../../../data/MarginAccount';
+import { Token } from '../../../data/Token';
+import { formatNumberInput, roundPercentage, truncateDecimals } from '../../../util/Numbers';
+import TokenAmountSelectInput from '../../portfolio/TokenAmountSelectInput';
+
+const SECONDARY_COLOR = '#CCDFED';
+
+export type AddCollateralModalProps = {
+  marginAccount: MarginAccount;
+  marketInfo: MarketInfo;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
+};
+
+export default function AddCollateralModal(props: AddCollateralModalProps) {
+  const { marginAccount, marketInfo, isOpen, setIsOpen } = props;
+
+  const [collateralAmount, setCollateralAmount] = useState('');
+  const [collateralToken, setCollateralToken] = useState(marginAccount.token0);
+
+  const { address: userAddress } = useAccount();
+
+  const resetModal = () => {};
+
+  const tokenOptions = useMemo(() => {
+    return [marginAccount.token0, marginAccount.token1];
+  }, [marginAccount.token0, marginAccount.token1]);
+
+  const collateralTokenAPR = useMemo(() => {
+    return (
+      (collateralToken.address === marginAccount.token0.address ? marketInfo.borrowerAPR0 : marketInfo.borrowerAPR1) *
+      100
+    );
+  }, [collateralToken.address, marginAccount.token0.address, marketInfo.borrowerAPR0, marketInfo.borrowerAPR1]);
+
+  if (!userAddress || !isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title='Add Collateral'
+      setIsOpen={(open: boolean) => {
+        setIsOpen(open);
+        if (!open) {
+          resetModal();
+        }
+      }}
+      maxHeight='650px'
+    >
+      <div className='flex flex-col items-center justify-center gap-8 w-full mt-2'>
+        <div className='flex flex-col gap-1 w-full'>
+          <Text size='M' weight='bold'>
+            Collateral Amount
+          </Text>
+          <TokenAmountSelectInput
+            inputValue={collateralAmount}
+            onChange={(value) => {
+              const output = formatNumberInput(value);
+              if (output != null) {
+                const truncatedOutput = truncateDecimals(output, collateralToken.decimals);
+                setCollateralAmount(truncatedOutput);
+              }
+            }}
+            onSelect={(option: Token) => {
+              setCollateralAmount('');
+              setCollateralToken(option);
+            }}
+            options={tokenOptions}
+            selectedOption={collateralToken}
+          />
+        </div>
+        <div className='flex flex-col gap-1 w-full'>
+          <Text size='M' weight='bold'>
+            Current Interest Rate
+          </Text>
+          <Text size='L' weight='bold' color={SECONDARY_COLOR}>
+            {roundPercentage(collateralTokenAPR, 4)}% APR
+          </Text>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/earn/src/components/borrow/modal/AddCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/AddCollateralModal.tsx
@@ -241,11 +241,11 @@ export default function AddCollateralModal(props: AddCollateralModalProps) {
             <strong>
               {collateralAmount || '0.00'} {collateralToken.ticker}
             </strong>{' '}
-            as collateral to the{' '}
+            as collateral to this{' '}
             <strong>
               {marginAccount.token0.ticker}/{marginAccount.token1.ticker}
             </strong>{' '}
-            pair. Your total collateral for this token in this pair will be{' '}
+            smart wallet. Your total collateral for this token in this smart wallet will be{' '}
             <strong>
               {truncateDecimals(newCollateralBig.toString(), collateralToken.decimals)} {collateralToken.ticker}
             </strong>

--- a/earn/src/components/borrow/modal/AddCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/AddCollateralModal.tsx
@@ -164,9 +164,7 @@ export default function AddCollateralModal(props: AddCollateralModalProps) {
     setCollateralToken(marginAccount.token0);
   };
 
-  const tokenOptions = useMemo(() => {
-    return [marginAccount.token0, marginAccount.token1];
-  }, [marginAccount.token0, marginAccount.token1]);
+  const tokenOptions = [marginAccount.token0, marginAccount.token1];
 
   const existingCollateral =
     collateralToken.address === marginAccount.token0.address
@@ -175,19 +173,12 @@ export default function AddCollateralModal(props: AddCollateralModalProps) {
 
   const numericCollateralAmount = Number(collateralAmount) || 0;
 
-  const collateralAmountBig = useMemo(() => {
-    return new Big(numericCollateralAmount).mul(10 ** collateralToken.decimals);
-  }, [collateralToken.decimals, numericCollateralAmount]);
+  const collateralAmountBig = new Big(numericCollateralAmount).mul(10 ** collateralToken.decimals);
 
-  const existingCollateralBig = useMemo(() => {
-    return new Big(existingCollateral).mul(10 ** collateralToken.decimals);
-  }, [collateralToken.decimals, existingCollateral]);
+  const existingCollateralBig = new Big(existingCollateral).mul(10 ** collateralToken.decimals);
 
   const numericUserBalance = Number(userBalance?.formatted ?? 0) || 0;
-  const userBalanceBig = useMemo(
-    () => new Big(numericUserBalance).mul(10 ** collateralToken.decimals),
-    [collateralToken.decimals, numericUserBalance]
-  );
+  const userBalanceBig = new Big(numericUserBalance).mul(10 ** collateralToken.decimals);
 
   if (!userAddress || !isOpen) {
     return null;

--- a/earn/src/components/borrow/modal/BorrowModal.tsx
+++ b/earn/src/components/borrow/modal/BorrowModal.tsx
@@ -1,0 +1,37 @@
+import { SendTransactionResult } from '@wagmi/core';
+import Modal from 'shared/lib/components/common/Modal';
+import { useAccount } from 'wagmi';
+
+export type BorrowModalProps = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
+};
+
+export default function BorrowModal(props: BorrowModalProps) {
+  const { isOpen, setIsOpen } = props;
+
+  const { address: userAddress } = useAccount();
+
+  const resetModal = () => {};
+
+  if (!userAddress || !isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title='Borrow'
+      setIsOpen={(open: boolean) => {
+        setIsOpen(open);
+        if (!open) {
+          resetModal();
+        }
+      }}
+      maxHeight='650px'
+    >
+      <div className='w-full'></div>
+    </Modal>
+  );
+}

--- a/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
@@ -98,11 +98,11 @@ export default function RemoveCollateralModal(props: RemoveCollateralModalProps)
             <strong>
               {collateralAmount || '0.00'} {collateralToken.ticker}
             </strong>{' '}
-            collateral from the{' '}
+            collateral from this{' '}
             <strong>
               {marginAccount.token0.ticker}/{marginAccount.token1.ticker}
             </strong>{' '}
-            pair. Your total collateral for this token in this pair will be{' '}
+            smart wallet. Your total collateral for this token in this smart wallet will be{' '}
             <strong>
               {truncateDecimals(newCollateralAmount.toString(), collateralToken.decimals)} {collateralToken.ticker}
             </strong>

--- a/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react';
+
+import { SendTransactionResult } from '@wagmi/core';
+import Modal from 'shared/lib/components/common/Modal';
+import { Text } from 'shared/lib/components/common/Typography';
+import { useAccount } from 'wagmi';
+
+import { MarginAccount, MarketInfo } from '../../../data/MarginAccount';
+import { Token } from '../../../data/Token';
+import { formatNumberInput, roundPercentage, truncateDecimals } from '../../../util/Numbers';
+import TokenAmountSelectInput from '../../portfolio/TokenAmountSelectInput';
+
+const SECONDARY_COLOR = '#CCDFED';
+
+export type RemoveCollateralModalProps = {
+  marginAccount: MarginAccount;
+  marketInfo: MarketInfo;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
+};
+
+export default function RemoveCollateralModal(props: RemoveCollateralModalProps) {
+  const { marginAccount, marketInfo, isOpen, setIsOpen } = props;
+
+  const [collateralAmount, setCollateralAmount] = useState('');
+  const [collateralToken, setCollateralToken] = useState(marginAccount.token0);
+
+  const { address: userAddress } = useAccount();
+
+  const resetModal = () => {};
+
+  const tokenOptions = useMemo(() => {
+    return [marginAccount.token0, marginAccount.token1];
+  }, [marginAccount.token0, marginAccount.token1]);
+
+  const collateralTokenAPR = useMemo(() => {
+    return (
+      (collateralToken.address === marginAccount.token0.address ? marketInfo.borrowerAPR0 : marketInfo.borrowerAPR1) *
+      100
+    );
+  }, [collateralToken.address, marginAccount.token0.address, marketInfo.borrowerAPR0, marketInfo.borrowerAPR1]);
+
+  if (!userAddress || !isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title='Remove Collateral'
+      setIsOpen={(open: boolean) => {
+        setIsOpen(open);
+        if (!open) {
+          resetModal();
+        }
+      }}
+      maxHeight='650px'
+    >
+      <div className='flex flex-col items-center justify-center gap-8 w-full mt-2'>
+        <div className='flex flex-col gap-1 w-full'>
+          <Text size='M' weight='bold'>
+            Collateral Amount
+          </Text>
+          <TokenAmountSelectInput
+            inputValue={collateralAmount}
+            onChange={(value) => {
+              const output = formatNumberInput(value);
+              if (output != null) {
+                const truncatedOutput = truncateDecimals(output, collateralToken.decimals);
+                setCollateralAmount(truncatedOutput);
+              }
+            }}
+            onSelect={(option: Token) => {
+              setCollateralAmount('');
+              setCollateralToken(option);
+            }}
+            options={tokenOptions}
+            selectedOption={collateralToken}
+          />
+        </div>
+        <div className='flex flex-col gap-1 w-full'>
+          <Text size='M' weight='bold'>
+            Current Interest Rate
+          </Text>
+          <Text size='L' weight='bold' color={SECONDARY_COLOR}>
+            {roundPercentage(collateralTokenAPR, 4)}% APR
+          </Text>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { SendTransactionResult } from '@wagmi/core';
 import Big from 'big.js';
@@ -31,9 +31,7 @@ export default function RemoveCollateralModal(props: RemoveCollateralModalProps)
 
   const resetModal = () => {};
 
-  const tokenOptions = useMemo(() => {
-    return [marginAccount.token0, marginAccount.token1];
-  }, [marginAccount.token0, marginAccount.token1]);
+  const tokenOptions = [marginAccount.token0, marginAccount.token1];
 
   const existingCollateral =
     collateralToken.address === marginAccount.token0.address
@@ -42,14 +40,8 @@ export default function RemoveCollateralModal(props: RemoveCollateralModalProps)
 
   const numericCollateralAmount = Number(collateralAmount) || 0;
 
-  const existingCollateralBig = useMemo(
-    () => new Big(existingCollateral).mul(10 ** collateralToken.decimals),
-    [collateralToken.decimals, existingCollateral]
-  );
-  const numericCollateralAmountBig = useMemo(
-    () => new Big(numericCollateralAmount).mul(10 ** collateralToken.decimals),
-    [collateralToken.decimals, numericCollateralAmount]
-  );
+  const existingCollateralBig = new Big(existingCollateral).mul(10 ** collateralToken.decimals);
+  const numericCollateralAmountBig = new Big(numericCollateralAmount).mul(10 ** collateralToken.decimals);
 
   const newCollateralAmount = Math.max(
     existingCollateralBig

--- a/earn/src/components/borrow/modal/RepayModal.tsx
+++ b/earn/src/components/borrow/modal/RepayModal.tsx
@@ -1,0 +1,37 @@
+import { SendTransactionResult } from '@wagmi/core';
+import Modal from 'shared/lib/components/common/Modal';
+import { useAccount } from 'wagmi';
+
+export type RepayModalProps = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
+};
+
+export default function RepayModal(props: RepayModalProps) {
+  const { isOpen, setIsOpen } = props;
+
+  const { address: userAddress } = useAccount();
+
+  const resetModal = () => {};
+
+  if (!userAddress || !isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title='Repay'
+      setIsOpen={(open: boolean) => {
+        setIsOpen(open);
+        if (!open) {
+          resetModal();
+        }
+      }}
+      maxHeight='650px'
+    >
+      <div className='w-full'></div>
+    </Modal>
+  );
+}

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -20,7 +20,11 @@ import BorrowGraph, { BorrowGraphData } from '../components/borrow/BorrowGraph';
 import { BorrowMetrics } from '../components/borrow/BorrowMetrics';
 import GlobalStatsTable from '../components/borrow/GlobalStatsTable';
 import ManageAccountButtons from '../components/borrow/ManageAccountButtons';
+import AddCollateralModal from '../components/borrow/modal/AddCollateralModal';
+import BorrowModal from '../components/borrow/modal/BorrowModal';
 import NewSmartWalletModal from '../components/borrow/modal/NewSmartWalletModal';
+import RemoveCollateralModal from '../components/borrow/modal/RemoveCollateralModal';
+import RepayModal from '../components/borrow/modal/RepayModal';
 import SmartWalletButton, { NewSmartWalletButton } from '../components/borrow/SmartWalletButton';
 import PendingTxnModal, { PendingTxnModalStatus } from '../components/common/PendingTxnModal';
 import {
@@ -147,6 +151,10 @@ export default function BorrowPage() {
   const [cachedMarketInfos, setCachedMarketInfos] = useState<Map<string, MarketInfo>>(new Map());
   const [selectedMarketInfo, setSelectedMarketInfo] = useState<MarketInfo | undefined>(undefined);
   const [newSmartWalletModalOpen, setNewSmartWalletModalOpen] = useState(false);
+  const [isAddCollateralModalOpen, setIsAddCollateralModalOpen] = useState(false);
+  const [isRemoveCollateralModalOpen, setIsRemoveCollateralModalOpen] = useState(false);
+  const [isBorrowModalOpen, setIsBorrowModalOpen] = useState(false);
+  const [isRepayModalOpen, setIsRepayModalOpen] = useState(false);
   const [isPendingTxnModalOpen, setIsPendingTxnModalOpen] = useState(false);
   const [pendingTxn, setPendingTxn] = useState<SendTransactionResult | null>(null);
   const [pendingTxnModalStatus, setPendingTxnModalStatus] = useState<PendingTxnModalStatus | null>(null);
@@ -405,7 +413,20 @@ export default function BorrowPage() {
               <p>Monitor and manage</p>
               <p>your smart wallet</p>
             </Text>
-            <ManageAccountButtons />
+            <ManageAccountButtons
+              onAddCollateral={() => {
+                setIsAddCollateralModalOpen(true);
+              }}
+              onRemoveCollateral={() => {
+                setIsRemoveCollateralModalOpen(true);
+              }}
+              onBorrow={() => {
+                setIsBorrowModalOpen(true);
+              }}
+              onRepay={() => {
+                setIsRepayModalOpen(true);
+              }}
+            />
           </MonitorContainer>
           <GraphContainer>{graphData && graphData.length > 0 && <BorrowGraph graphData={graphData} />}</GraphContainer>
           <MetricsContainer>
@@ -430,6 +451,26 @@ export default function BorrowPage() {
           setPendingTxn={setPendingTxn}
         />
       )}
+      {selectedMarginAccount && selectedMarketInfo && (
+        <>
+          <AddCollateralModal
+            marginAccount={selectedMarginAccount}
+            marketInfo={selectedMarketInfo}
+            isOpen={isAddCollateralModalOpen}
+            setIsOpen={setIsAddCollateralModalOpen}
+            setPendingTxn={setPendingTxn}
+          />
+          <RemoveCollateralModal
+            marginAccount={selectedMarginAccount}
+            marketInfo={selectedMarketInfo}
+            isOpen={isRemoveCollateralModalOpen}
+            setIsOpen={setIsRemoveCollateralModalOpen}
+            setPendingTxn={setPendingTxn}
+          />
+        </>
+      )}
+      <BorrowModal isOpen={isBorrowModalOpen} setIsOpen={setIsBorrowModalOpen} setPendingTxn={setPendingTxn} />
+      <RepayModal isOpen={isRepayModalOpen} setIsOpen={setIsRepayModalOpen} setPendingTxn={setPendingTxn} />
       <PendingTxnModal
         isOpen={isPendingTxnModalOpen}
         setIsOpen={(isOpen: boolean) => {


### PR DESCRIPTION
As the title suggests, I am adding the remainder of the modals to the earn borrow page and implementing the add collateral modal. The rest are waiting on some contracts to get deployed. Here is an image of the add collateral modal:
<img width="565" alt="Screenshot 2023-02-16 at 9 20 25 AM" src="https://user-images.githubusercontent.com/17186604/219390736-c8dde030-c979-44eb-8c0f-3452167141a5.png">
