### PR TITLE
Starting to add multicall to optimize our requests

### DIFF
--- a/earn/package.json
+++ b/earn/package.json
@@ -27,6 +27,7 @@
     "big.js": "^6.1.1",
     "color.js": "^1.2.0",
     "date-fns": "^2.28.0",
+    "ethereum-multicall": "^2.15.0",
     "ethers": "^5.7.0",
     "graphql": "^16.5.0",
     "graphql-tag": "^2.12.6",

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -1,17 +1,18 @@
 import Big from 'big.js';
 import { secondsInYear } from 'date-fns';
-import { ethers } from 'ethers';
+import { ContractCallContext, ContractCallResults, Multicall } from 'ethereum-multicall';
+import { BigNumber, ethers } from 'ethers';
 import JSBI from 'jsbi';
 import { FeeTier, NumericFeeTierToEnum } from 'shared/lib/data/FeeTier';
 import { Address, Chain } from 'wagmi';
 
+import MarginAccountABI from '../assets/abis/MarginAccount.json';
+import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
 import { makeEtherscanRequest } from '../util/Etherscan';
 import { toBig } from '../util/Numbers';
-// import { getAmountsForLiquidity, getValueOfLiquidity } from '../util/Uniswap';
-// import { UniswapPosition } from './actions/Actions';
-import { ALOE_II_FACTORY_ADDRESS, ALOE_II_ORACLE } from './constants/Addresses';
+import { ALOE_II_BORROWER_LENS_ADDRESS, ALOE_II_FACTORY_ADDRESS, ALOE_II_ORACLE } from './constants/Addresses';
 import { TOPIC0_CREATE_BORROWER_EVENT } from './constants/Signatures';
 import { BIGQ96 } from './constants/Values';
 import { Token } from './Token';
@@ -116,68 +117,99 @@ export async function fetchMarginAccountPreviews(
   userAddress: string,
   uniswapPoolDataMap: Map<string, UniswapPoolInfo>
 ): Promise<MarginAccountPreview[]> {
+  const multicall = new Multicall({ ethersProvider: provider, tryAggregate: true });
   const marginAccountsAddresses = await getMarginAccountsForUser(chain, userAddress, provider);
-  const marginAccounts: Promise<MarginAccountPreview | null>[] = marginAccountsAddresses.map(
-    async ({ address: accountAddress, uniswapPool }) => {
-      const uniswapPoolInfo = uniswapPoolDataMap.get(`0x${uniswapPool}`) ?? null;
+  let contractCallContext: ContractCallContext[] = [];
 
-      if (uniswapPoolInfo === null) return null;
+  marginAccountsAddresses.forEach(({ address: accountAddress, uniswapPool }) => {
+    const uniswapPoolInfo = uniswapPoolDataMap.get(`0x${uniswapPool}`) ?? null;
 
-      const token0 = uniswapPoolInfo.token0;
-      const token1 = uniswapPoolInfo.token1;
-      const feeTier = NumericFeeTierToEnum(uniswapPoolInfo.fee);
+    if (uniswapPoolInfo === null) return;
 
-      if (!token0 || !token1) return null;
+    const token0 = uniswapPoolInfo.token0;
+    const token1 = uniswapPoolInfo.token1;
+    const feeTier = NumericFeeTierToEnum(uniswapPoolInfo.fee);
 
-      let assetsData = null;
-      let liabilitiesData = null;
-      let healthData = null;
+    if (!token0 || !token1) return;
 
-      try {
-        assetsData = await borrowerLensContract.getAssets(accountAddress);
-        liabilitiesData = await borrowerLensContract.getLiabilities(accountAddress, true);
-        healthData = await borrowerLensContract.getHealth(accountAddress, true);
-      } catch (e) {
-        console.error(`borrowerLens.getAssets failed for account ${accountAddress} in pool ${uniswapPool}`, e);
-        return null;
-      }
+    contractCallContext.push({
+      reference: accountAddress,
+      contractAddress: ALOE_II_BORROWER_LENS_ADDRESS,
+      abi: MarginAccountLensABI,
+      calls: [
+        {
+          reference: 'getAssets',
+          methodName: 'getAssets',
+          methodParameters: [accountAddress],
+        },
+        {
+          reference: 'getLiabilities',
+          methodName: 'getLiabilities',
+          methodParameters: [accountAddress, true],
+        },
+        {
+          reference: 'getHealth',
+          methodName: 'getHealth',
+          methodParameters: [accountAddress, true],
+        },
+      ],
+      context: {
+        feeTier: feeTier,
+        token0: token0,
+        token1: token1,
+        accountAddress: accountAddress,
+        uniswapPool: uniswapPool,
+      },
+    });
+  });
 
-      const health = healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1];
-      const assets: Assets = {
-        token0Raw: Big(assetsData.fixed0.toString())
-          .div(10 ** token0.decimals)
-          .toNumber(),
-        token1Raw: Big(assetsData.fixed1.toString())
-          .div(10 ** token1.decimals)
-          .toNumber(),
-        uni0: Big(assetsData.fluid0C.toString())
-          .div(10 ** token0.decimals)
-          .toNumber(),
-        uni1: Big(assetsData.fluid1C.toString())
-          .div(10 ** token1.decimals)
-          .toNumber(),
-      };
-      const liabilities: Liabilities = {
-        amount0: Big(liabilitiesData.amount0.toString())
-          .div(10 ** token0.decimals)
-          .toNumber(),
-        amount1: Big(liabilitiesData.amount1.toString())
-          .div(10 ** token1.decimals)
-          .toNumber(),
-      };
-      return {
-        address: accountAddress,
-        uniswapPool,
-        token0,
-        token1,
-        feeTier,
-        assets,
-        liabilities,
-        health: health.div(1e9).toNumber() / 1e9,
-      };
-    }
-  );
-  return (await Promise.all(marginAccounts)).filter((account) => account !== null) as MarginAccountPreview[];
+  const results = (await multicall.call(contractCallContext)).results;
+
+  let marginAccounts: MarginAccountPreview[] = [];
+
+  Object.values(results).forEach((value) => {
+    const contractResults = value.callsReturnContext;
+    const { feeTier, token0, token1, accountAddress, uniswapPool } = value.originalContractCallContext.context;
+    const assetsData = contractResults[0].returnValues;
+    const liabilitiesData = contractResults[1].returnValues;
+    const healthData = contractResults[2].returnValues;
+    const healthData0 = Big(BigNumber.from(healthData[0].hex).toString());
+    const healthData1 = Big(BigNumber.from(healthData[1].hex).toString());
+    const health = healthData0.lt(healthData1) ? healthData0 : healthData1;
+    const assets: Assets = {
+      token0Raw: Big(BigNumber.from(assetsData[0].hex).toString())
+        .div(10 ** token0.decimals)
+        .toNumber(),
+      token1Raw: Big(BigNumber.from(assetsData[1].hex).toString())
+        .div(10 ** token1.decimals)
+        .toNumber(),
+      uni0: Big(BigNumber.from(assetsData[4].hex).toString())
+        .div(10 ** token0.decimals)
+        .toNumber(),
+      uni1: Big(BigNumber.from(assetsData[5].hex).toString())
+        .div(10 ** token1.decimals)
+        .toNumber(),
+    };
+    const liabilities: Liabilities = {
+      amount0: Big(BigNumber.from(liabilitiesData[0].hex).toString())
+        .div(10 ** token0.decimals)
+        .toNumber(),
+      amount1: Big(BigNumber.from(liabilitiesData[1].hex).toString())
+        .div(10 ** token1.decimals)
+        .toNumber(),
+    };
+    marginAccounts.push({
+      address: accountAddress,
+      uniswapPool,
+      token0,
+      token1,
+      feeTier,
+      assets,
+      liabilities,
+      health: health.div(1e9).toNumber() / 1e9,
+    });
+  });
+  return marginAccounts;
 }
 
 export async function fetchMarketInfoFor(
@@ -224,56 +256,78 @@ export async function fetchMarginAccount(
 ): Promise<{
   marginAccount: MarginAccount;
 }> {
-  const results = await Promise.all([
-    marginAccountContract.TOKEN0(),
-    marginAccountContract.TOKEN1(),
-    marginAccountContract.LENDER0(),
-    marginAccountContract.LENDER1(),
-    marginAccountContract.UNISWAP_POOL(),
-    marginAccountLensContract.getAssets(marginAccountAddress),
-    marginAccountLensContract.getLiabilities(marginAccountAddress, true),
-    marginAccountLensContract.getHealth(accountAddress, true),
-  ]);
+  const multicall = new Multicall({ ethersProvider: provider, tryAggregate: true });
 
-  const uniswapPool = results[4];
+  const contractCallContext: ContractCallContext[] = [
+    {
+      reference: 'marginAccountContract',
+      contractAddress: marginAccountAddress,
+      abi: MarginAccountABI,
+      calls: [
+        { reference: 'token0', methodName: 'TOKEN0', methodParameters: [] },
+        { reference: 'token1', methodName: 'TOKEN1', methodParameters: [] },
+        { reference: 'lender0', methodName: 'LENDER0', methodParameters: [] },
+        { reference: 'lender1', methodName: 'LENDER1', methodParameters: [] },
+        { reference: 'uniswapPool', methodName: 'UNISWAP_POOL', methodParameters: [] },
+      ],
+    },
+    {
+      reference: 'marginAccountLensContract',
+      contractAddress: ALOE_II_BORROWER_LENS_ADDRESS,
+      abi: MarginAccountLensABI,
+      calls: [
+        { reference: 'assets', methodName: 'getAssets', methodParameters: [marginAccountAddress] },
+        { reference: 'liabilities', methodName: 'getLiabilities', methodParameters: [marginAccountAddress, true] },
+        { reference: 'health', methodName: 'getHealth', methodParameters: [accountAddress, true] },
+      ],
+    },
+  ];
+
+  const results: ContractCallResults = await multicall.call(contractCallContext);
+  const marginAccountContractResults = results.results['marginAccountContract'].callsReturnContext;
+  const marginAccountLensContractResults = results.results['marginAccountLensContract'].callsReturnContext;
+  const token0 = getToken(chain.id, marginAccountContractResults[0].returnValues[0]);
+  const token1 = getToken(chain.id, marginAccountContractResults[1].returnValues[0]);
+  const lender0 = marginAccountContractResults[2].returnValues[0];
+  const lender1 = marginAccountContractResults[3].returnValues[0];
+  const uniswapPool = marginAccountContractResults[4].returnValues[0];
+  const assetsData = marginAccountLensContractResults[0].returnValues;
+  const liabilitiesData = marginAccountLensContractResults[1].returnValues;
+  const healthData = marginAccountLensContractResults[2].returnValues;
+
   const uniswapPoolContract = new ethers.Contract(uniswapPool, UniswapV3PoolABI, provider);
   const volatilityOracleContract = new ethers.Contract(ALOE_II_ORACLE, VolatilityOracleABI, provider);
-  const token0 = getToken(chain.id, results[0] as Address);
-  const token1 = getToken(chain.id, results[1] as Address);
-  const lender0 = results[2] as Address;
-  const lender1 = results[3] as Address;
-  const assetsData = results[5];
-  const liabilitiesData = results[6];
   const [feeTier, oracleResult] = await Promise.all([
     uniswapPoolContract.fee(),
     volatilityOracleContract.consult(uniswapPool),
   ]);
 
   const assets: Assets = {
-    token0Raw: Big(assetsData.fixed0.toString())
+    token0Raw: Big(BigNumber.from(assetsData[0].hex).toString())
       .div(10 ** token0.decimals)
       .toNumber(),
-    token1Raw: Big(assetsData.fixed1.toString())
+    token1Raw: Big(BigNumber.from(assetsData[1].hex).toString())
       .div(10 ** token1.decimals)
       .toNumber(),
-    uni0: Big(assetsData.fluid0C.toString())
+    uni0: Big(BigNumber.from(assetsData[4].hex).toString())
       .div(10 ** token0.decimals)
       .toNumber(),
-    uni1: Big(assetsData.fluid1C.toString())
+    uni1: Big(BigNumber.from(assetsData[5].hex).toString())
       .div(10 ** token1.decimals)
       .toNumber(),
   };
   const liabilities: Liabilities = {
-    amount0: Big(liabilitiesData.amount0.toString())
+    amount0: Big(BigNumber.from(liabilitiesData[0].hex).toString())
       .div(10 ** token0.decimals)
       .toNumber(),
-    amount1: Big(liabilitiesData.amount1.toString())
+    amount1: Big(BigNumber.from(liabilitiesData[1].hex).toString())
       .div(10 ** token1.decimals)
       .toNumber(),
   };
 
-  const healthData = results[7];
-  const health = healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1];
+  const healthData0 = Big(BigNumber.from(healthData[0].hex).toString());
+  const healthData1 = Big(BigNumber.from(healthData[1].hex).toString());
+  const health = healthData0.lt(healthData1) ? healthData0 : healthData1;
 
   return {
     marginAccount: {
@@ -308,224 +362,6 @@ export function priceToSqrtRatio(price: number, token0Decimals: number, token1De
     .sqrt()
     .mul(BIGQ96);
 }
-
-// function _computeProbePrices(sqrtMeanPriceX96: Big, sigma: number): [Big, Big] {
-//   sigma = Math.min(Math.max(ALOE_II_SIGMA_MIN, sigma), ALOE_II_SIGMA_MAX);
-//   sigma *= ALOE_II_SIGMA_SCALER;
-
-//   let a = sqrtMeanPriceX96.mul(new Big((1 - sigma) * 1e18).sqrt()).div(1e9);
-//   let b = sqrtMeanPriceX96.mul(new Big((1 + sigma) * 1e18).sqrt()).div(1e9);
-
-//   // Constrain to be within TickMath's MIN_TICK and MAX_TICK
-//   if (a.lt('4295128740')) {
-//     a = new Big('4295128740');
-//   }
-//   if (b.gt('1461446703485210103287273052203988822378723970341')) {
-//     b = new Big('1461446703485210103287273052203988822378723970341');
-//   }
-//   return [a, b];
-// }
-
-// export function getAssets(
-//   marginAccount: MarginAccount,
-//   uniswapPositions: readonly UniswapPosition[],
-//   a: Big,
-//   b: Big,
-//   c: Big
-// ) {
-//   const tickA = TickMath.getTickAtSqrtRatio(JSBI.BigInt(a.toFixed(0)));
-//   const tickB = TickMath.getTickAtSqrtRatio(JSBI.BigInt(b.toFixed(0)));
-//   const tickC = TickMath.getTickAtSqrtRatio(JSBI.BigInt(c.toFixed(0)));
-
-//   let fixed0 = marginAccount.assets.token0Raw;
-//   let fixed1 = marginAccount.assets.token1Raw;
-
-//   let fluid1A = 0;
-//   let fluid1B = 0;
-//   let fluid0C = 0;
-//   let fluid1C = 0;
-
-//   for (const position of uniswapPositions) {
-//     const { liquidity, lower, upper } = position;
-//     if (lower === null || upper === null) {
-//       console.error('Attempted to compute liquidation thresholds for account with malformed Uniswap Position');
-//       console.error(position);
-//       continue;
-//     }
-
-//     fluid1A += getValueOfLiquidity(liquidity, lower, upper, tickA, marginAccount.token1.decimals);
-//     fluid1B += getValueOfLiquidity(liquidity, lower, upper, tickB, marginAccount.token1.decimals);
-//     const temp = getAmountsForLiquidity(
-//       liquidity,
-//       lower,
-//       upper,
-//       tickC,
-//       marginAccount.token0.decimals,
-//       marginAccount.token1.decimals
-//     );
-//     fluid0C += temp[0];
-//     fluid1C += temp[1];
-//   }
-
-//   return {
-//     fixed0,
-//     fixed1,
-//     fluid1A,
-//     fluid1B,
-//     fluid0C,
-//     fluid1C,
-//   };
-// }
-
-// function _computeLiquidationIncentive(
-//   assets0: number,
-//   assets1: number,
-//   liabilities0: number,
-//   liabilities1: number,
-//   token0Decimals: number,
-//   token1Decimals: number,
-//   sqrtPriceX96: Big
-// ): number {
-//   const price = sqrtRatioToPrice(sqrtPriceX96, token0Decimals, token1Decimals);
-
-//   let reward = 0;
-//   if (liabilities0 > assets0) {
-//     const shortfall = liabilities0 - assets0;
-//     reward += (shortfall * price) / ALOE_II_LIQUIDATION_INCENTIVE;
-//   }
-//   if (liabilities1 > assets1) {
-//     const shortfall = liabilities1 - assets1;
-//     reward += shortfall / ALOE_II_LIQUIDATION_INCENTIVE;
-//   }
-//   return reward;
-// }
-
-// export function isSolvent(
-//   marginAccount: MarginAccount,
-//   uniswapPositions: readonly UniswapPosition[],
-//   sqrtPriceX96: Big
-// ) {
-//   const token0Decimals = marginAccount.token0.decimals;
-//   const token1Decimals = marginAccount.token1.decimals;
-
-//   const [a, b] = _computeProbePrices(sqrtPriceX96, marginAccount.iv);
-//   const priceA = sqrtRatioToPrice(a, token0Decimals, token1Decimals);
-//   const priceB = sqrtRatioToPrice(b, token0Decimals, token1Decimals);
-
-//   const mem = getAssets(marginAccount, uniswapPositions, a, b, sqrtPriceX96);
-//   let liabilities0 = marginAccount.liabilities.amount0;
-//   let liabilities1 = marginAccount.liabilities.amount1;
-
-//   const liquidationIncentive = _computeLiquidationIncentive(
-//     mem.fixed0 + mem.fluid0C,
-//     mem.fixed1 + mem.fluid1C,
-//     liabilities0,
-//     liabilities1,
-//     token0Decimals,
-//     token1Decimals,
-//     sqrtPriceX96
-//   );
-
-//   liabilities0 += liabilities0 / ALOE_II_MAX_LEVERAGE;
-//   liabilities1 += liabilities1 / ALOE_II_MAX_LEVERAGE + liquidationIncentive;
-
-//   const liabilitiesA = liabilities1 + liabilities0 * priceA;
-//   const assetsA = mem.fluid1A + mem.fixed1 + mem.fixed0 * priceA;
-//   const healthA = liabilitiesA > 0 ? assetsA / liabilitiesA : 1000;
-
-//   const liabilitiesB = liabilities1 + liabilities0 * priceB;
-//   const assetsB = mem.fluid1B + mem.fixed1 + mem.fixed0 * priceB;
-//   const healthB = liabilitiesB > 0 ? assetsB / liabilitiesB : 1000;
-
-//   return {
-//     priceA,
-//     priceB,
-//     assetsA,
-//     assetsB,
-//     liabilitiesA,
-//     liabilitiesB,
-//     atA: assetsA >= liabilitiesA,
-//     atB: assetsB >= liabilitiesB,
-//     health: Math.min(healthA, healthB),
-//   };
-// }
-
-// export function computeLiquidationThresholds(
-//   marginAccount: MarginAccount,
-//   uniswapPositions: UniswapPosition[],
-//   iterations: number = 120,
-//   precision: number = 7
-// ): LiquidationThresholds {
-//   let result: LiquidationThresholds = {
-//     lower: 0,
-//     upper: 0,
-//   };
-
-//   const MINPRICE = new Big(TickMath.MIN_SQRT_RATIO.toString(10)).mul(1.23);
-//   const MAXPRICE = new Big(TickMath.MAX_SQRT_RATIO.toString()).div(1.23);
-
-//   // Find lower liquidation threshold
-//   const isSolventAtMin = isSolvent(marginAccount, uniswapPositions, MINPRICE);
-//   if (isSolventAtMin.atA && isSolventAtMin.atB) {
-//     // if solvent at beginning, short-circuit
-//     result.lower = sqrtRatioToPrice(MINPRICE, marginAccount.token0.decimals, marginAccount.token1.decimals);
-//   } else {
-//     // Start binary search
-//     let lowerBoundSqrtPrice = MINPRICE;
-//     let upperBoundSqrtPrice = marginAccount.sqrtPriceX96;
-//     let searchPrice: Big = new Big(0);
-//     for (let i = 0; i < iterations; i++) {
-//       const prevSearchPrice = searchPrice;
-//       searchPrice = lowerBoundSqrtPrice.add(upperBoundSqrtPrice).div(2);
-//       if (areWithinNSigDigs(searchPrice, prevSearchPrice, precision)) {
-//         // binary search has converged
-//         break;
-//       }
-//       const isSolventAtSearchPrice = isSolvent(marginAccount, uniswapPositions, searchPrice);
-//       const isLiquidatableAtSearchPrice = !isSolventAtSearchPrice.atA || !isSolventAtSearchPrice.atB;
-//       if (isLiquidatableAtSearchPrice) {
-//         // liquidation threshold is lower
-//         lowerBoundSqrtPrice = searchPrice;
-//       } else {
-//         // liquidation threshold is higher
-//         upperBoundSqrtPrice = searchPrice;
-//       }
-//     }
-//     result.lower = sqrtRatioToPrice(searchPrice, marginAccount.token0.decimals, marginAccount.token1.decimals);
-//   }
-
-//   // Find upper liquidation threshold
-//   const isSolventAtMax = isSolvent(marginAccount, uniswapPositions, MAXPRICE);
-//   if (isSolventAtMax.atA && isSolventAtMax.atB) {
-//     // if solvent at end, short-circuit
-//     result.upper = sqrtRatioToPrice(MAXPRICE, marginAccount.token0.decimals, marginAccount.token1.decimals);
-//   } else {
-//     // Start binary search
-//     let lowerBoundSqrtPrice = marginAccount.sqrtPriceX96;
-//     let upperBoundSqrtPrice = MAXPRICE;
-//     let searchPrice: Big = new Big(0);
-//     for (let i = 0; i < iterations; i++) {
-//       const prevSearchPrice = searchPrice;
-//       searchPrice = lowerBoundSqrtPrice.add(upperBoundSqrtPrice).div(2);
-//       if (areWithinNSigDigs(searchPrice, prevSearchPrice, precision)) {
-//         // binary search has converged
-//         break;
-//       }
-//       const isSolventAtSearchPrice = isSolvent(marginAccount, uniswapPositions, searchPrice);
-//       const isLiquidatableAtSearchPrice = !isSolventAtSearchPrice.atA || !isSolventAtSearchPrice.atB;
-//       if (isLiquidatableAtSearchPrice) {
-//         // liquidation threshold is higher
-//         upperBoundSqrtPrice = searchPrice;
-//       } else {
-//         // liquidation threshold is lower
-//         lowerBoundSqrtPrice = searchPrice;
-//       }
-//     }
-//     result.upper = sqrtRatioToPrice(searchPrice, marginAccount.token0.decimals, marginAccount.token1.decimals);
-//   }
-
-//   return result;
-// }
 
 export function sumAssetsPerToken(assets: Assets): [number, number] {
   return [assets.token0Raw + assets.uni0, assets.token1Raw + assets.uni1];

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import AppPage from 'shared/lib/components/common/AppPage';
 import { Text } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
-import { Address, useAccount, useContract, useProvider, useSigner } from 'wagmi';
+import { Address, useAccount, useContract, useProvider } from 'wagmi';
 
 import { ChainContext } from '../App';
 import KittyLensAbi from '../assets/abis/KittyLens.json';

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -12,7 +12,6 @@ import { Address, useAccount, useContract, useProvider, useSigner } from 'wagmi'
 
 import { ChainContext } from '../App';
 import KittyLensAbi from '../assets/abis/KittyLens.json';
-import MarginAccountABI from '../assets/abis/MarginAccount.json';
 import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import BorrowGraph, { BorrowGraphData } from '../components/borrow/BorrowGraph';
@@ -213,7 +212,6 @@ export default function BorrowPage() {
       if (borrowerLensContract == null || userAddress === undefined || availablePools.size === 0) return;
       const marginAccountPreviews = await fetchMarginAccountPreviews(
         activeChain,
-        borrowerLensContract,
         provider,
         userAddress,
         availablePools
@@ -244,16 +242,12 @@ export default function BorrowPage() {
     }
     async function fetch() {
       if (selectedMarginAccountPreview == null || borrowerLensContract == null) return;
-      const borrowerContract = new ethers.Contract(selectedMarginAccountPreview.address, MarginAccountABI, provider);
       const result = await fetchMarginAccount(
         selectedMarginAccountPreview.address,
         activeChain,
-        borrowerContract,
-        borrowerLensContract,
         provider,
         selectedMarginAccountPreview.address
       );
-      console.log(result);
       if (mounted) {
         setCachedMarginAccounts((prev) => {
           return new Map(prev).set(selectedMarginAccountPreview.address, result.marginAccount);

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import AppPage from 'shared/lib/components/common/AppPage';
 import { Text } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
-import { Address, useAccount, useContract, useProvider } from 'wagmi';
+import { Address, useAccount, useContract, useProvider, useSigner } from 'wagmi';
 
 import { ChainContext } from '../App';
 import KittyLensAbi from '../assets/abis/KittyLens.json';
@@ -253,6 +253,7 @@ export default function BorrowPage() {
         provider,
         selectedMarginAccountPreview.address
       );
+      console.log(result);
       if (mounted) {
         setCachedMarginAccounts((prev) => {
           return new Map(prev).set(selectedMarginAccountPreview.address, result.marginAccount);

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -8,8 +8,8 @@ export function convertBigNumbers(callReturnContext: CallReturnContext[]): CallR
       if (returnValue?.type === 'BigNumber' && returnValue?.hex) {
         returnValue = BigNumber.from(returnValue.hex);
       }
-      return returnValue as any[];
+      return returnValue;
     });
-    return value as CallReturnContext;
+    return value;
   });
 }

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -1,0 +1,14 @@
+import { CallReturnContext } from 'ethereum-multicall';
+import { BigNumber } from 'ethers';
+
+export function convertBigNumbers(callReturnContext: CallReturnContext[]): CallReturnContext[] {
+  return Object.values(callReturnContext).map((value) => {
+    value.returnValues = Object.values(value.returnValues).map((returnValue) => {
+      if (returnValue?.type === 'BigNumber') {
+        returnValue = BigNumber.from(returnValue.hex);
+      }
+      return returnValue as any[];
+    });
+    return value as CallReturnContext;
+  });
+}

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -4,6 +4,7 @@ import { BigNumber } from 'ethers';
 export function convertBigNumbers(callReturnContext: CallReturnContext[]): CallReturnContext[] {
   return callReturnContext.map((value) => {
     value.returnValues = value.returnValues.map((returnValue) => {
+      // If the return value is a BigNumber, convert it to an ethers BigNumber
       if (returnValue?.type === 'BigNumber' && returnValue?.hex) {
         returnValue = BigNumber.from(returnValue.hex);
       }

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -4,8 +4,8 @@ import { BigNumber } from 'ethers';
 export function convertBigNumbers(callReturnContext: CallReturnContext[]): CallReturnContext[] {
   return callReturnContext.map((value) => {
     value.returnValues = value.returnValues.map((returnValue) => {
-      if (returnValue?.type === 'BigNumber') {
-        returnValue = BigNumber.from(returnValue?.hex);
+      if (returnValue?.type === 'BigNumber' && returnValue?.hex) {
+        returnValue = BigNumber.from(returnValue.hex);
       }
       return returnValue as any[];
     });

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -2,10 +2,10 @@ import { CallReturnContext } from 'ethereum-multicall';
 import { BigNumber } from 'ethers';
 
 export function convertBigNumbers(callReturnContext: CallReturnContext[]): CallReturnContext[] {
-  return Object.values(callReturnContext).map((value) => {
-    value.returnValues = Object.values(value.returnValues).map((returnValue) => {
+  return callReturnContext.map((value) => {
+    value.returnValues = value.returnValues.map((returnValue) => {
       if (returnValue?.type === 'BigNumber') {
-        returnValue = BigNumber.from(returnValue.hex);
+        returnValue = BigNumber.from(returnValue?.hex);
       }
       return returnValue as any[];
     });

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -1,15 +1,15 @@
 import { CallReturnContext } from 'ethereum-multicall';
 import { BigNumber } from 'ethers';
 
-export function convertBigNumbers(callReturnContext: CallReturnContext[]): CallReturnContext[] {
-  return callReturnContext.map((value) => {
-    value.returnValues = value.returnValues.map((returnValue) => {
+export function convertBigNumbers(callReturnContexts: CallReturnContext[]): CallReturnContext[] {
+  return callReturnContexts.map((callReturnContext) => {
+    callReturnContext.returnValues = callReturnContext.returnValues.map((returnValue) => {
       // If the return value is a BigNumber, convert it to an ethers BigNumber
       if (returnValue?.type === 'BigNumber' && returnValue?.hex) {
         returnValue = BigNumber.from(returnValue.hex);
       }
       return returnValue;
     });
-    return value;
+    return callReturnContext;
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.0.10":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
+  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
@@ -7174,6 +7200,14 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
+ethereum-multicall@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/ethereum-multicall/-/ethereum-multicall-2.15.0.tgz#31706ab90fde3c4a204e9e2b094871619e6dbff8"
+  integrity sha512-Xyr/N9NYF4INiUKyg7k2AVjPMnpvRBVVZ4hSHenJF9sGBmVy3ZnSAXtLduWFBz/jogEx+mihfHRiaFkKM0yzWw==
+  dependencies:
+    "@ethersproject/providers" "^5.0.10"
+    ethers "^5.0.15"
+
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
@@ -7275,6 +7309,42 @@ ethereumjs-vm@^2.3.4:
     merkle-patricia-tree "^2.3.2"
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
+
+ethers@^5.0.15:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
+  integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
+  dependencies:
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/base64" "5.7.0"
+    "@ethersproject/basex" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/constants" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
+    "@ethersproject/pbkdf2" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/rlp" "5.7.0"
+    "@ethersproject/sha2" "5.7.0"
+    "@ethersproject/signing-key" "5.7.0"
+    "@ethersproject/solidity" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/units" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/web" "5.7.1"
+    "@ethersproject/wordlists" "5.7.0"
 
 ethers@^5.1.4, ethers@^5.6.1, ethers@^5.7.0:
   version "5.7.1"


### PR DESCRIPTION
Multicall allows us to combine multiple calls that would otherwise be sent separately, which helps us reduce the number of outgoing requests we need to send to populate the data on the page. This PR switches some of our existing fetches to use multicall. There is still plenty more work to be done in future PRs.