### PR TITLE
Adding condition to stop unnecessary fetches

### DIFF
--- a/earn/src/components/portfolio/modal/EarnInterestModal.tsx
+++ b/earn/src/components/portfolio/modal/EarnInterestModal.tsx
@@ -605,6 +605,7 @@ export default function EarnInterestModal(props: EarnInterestModalProps) {
     address: account?.address ?? '0x',
     token: selectedOption.address,
     chainId: activeChain.id,
+    enabled: isOpen,
   });
 
   useEffect(() => {

--- a/earn/src/components/portfolio/modal/SendCryptoModal.tsx
+++ b/earn/src/components/portfolio/modal/SendCryptoModal.tsx
@@ -184,6 +184,7 @@ export default function SendCryptoModal(props: SendCryptoModalProps) {
     address: account?.address ?? '0x',
     token: selectedOption.address,
     chainId: activeChain.id,
+    enabled: isOpen,
   });
 
   useEffect(() => {

--- a/earn/src/components/portfolio/modal/WithdrawModal.tsx
+++ b/earn/src/components/portfolio/modal/WithdrawModal.tsx
@@ -209,7 +209,7 @@ export default function WithdrawModal(props: WithdrawModalProps) {
   const { refetch: refetchMaxWithdraw, data: maxWithdraw } = useContractRead({
     address: activeKitty?.address,
     abi: KittyABI,
-    enabled: activeKitty != null,
+    enabled: activeKitty != null && account.address !== undefined && isOpen,
     functionName: 'maxWithdraw',
     chainId: activeChain.id,
     args: [account.address] as const,
@@ -218,7 +218,7 @@ export default function WithdrawModal(props: WithdrawModalProps) {
   const { refetch: refetchMaxRedeem, data: maxRedeem } = useContractRead({
     address: activeKitty?.address,
     abi: KittyABI,
-    enabled: activeKitty != null,
+    enabled: activeKitty != null && account.address !== undefined && isOpen,
     functionName: 'maxRedeem',
     chainId: activeChain.id,
     args: [account.address] as const,


### PR DESCRIPTION
A long overdue update to the portfolio page stops the page from fetching data from within the modal unless that modal is open. This saves us a lot of requests as this not only happened on each initial render but also when users hovered over a different asset.