### PR TITLE
Adding caching for lender pair data

### DIFF
--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -142,6 +142,9 @@ export type LendingPairPeerCardProps = {
 export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
   const { activeAsset, lendingPairs } = props;
   const { activeChain } = useContext(ChainContext);
+
+  const [cachedData, setCachedData] = useState<Map<string, number>>(new Map());
+
   const options: DropdownOption<LendingPair>[] = useMemo(() => {
     return lendingPairs.map((lendingPair) => {
       return {
@@ -161,6 +164,12 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
 
   useEffect(() => {
     let mounted = true;
+    console.log('fetching number of users', selectedLendingPair);
+    const cachedResult = cachedData.get(selectedOption.label);
+    if (cachedResult) {
+      setNumberOfUsers(cachedResult);
+      return;
+    }
     async function fetchNumberOfUsers() {
       const etherscanRequestLender0 = makeEtherscanRequest(
         7537163,
@@ -202,13 +211,17 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
       });
       if (mounted) {
         setNumberOfUsers(uniqueUsers.size);
+        setCachedData((cachedData) => {
+          // TODO: Make this into a custom hook (and make it more efficient)
+          return new Map(cachedData).set(selectedOption.label, uniqueUsers.size);
+        });
       }
     }
     fetchNumberOfUsers();
     return () => {
       mounted = false;
     };
-  }, [selectedLendingPair, activeChain]);
+  }, [selectedLendingPair, activeChain, cachedData, selectedOption.label]);
 
   const [activeUtilization, activeTotalSupply] = getActiveUtilizationAndTotalSupply(activeAsset, selectedLendingPair);
 

--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -164,7 +164,6 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
 
   useEffect(() => {
     let mounted = true;
-    console.log('fetching number of users', selectedLendingPair);
     const cachedResult = cachedData.get(selectedOption.label);
     if (cachedResult) {
       setNumberOfUsers(cachedResult);

--- a/earn/src/components/portfolio/modal/EarnInterestModal.tsx
+++ b/earn/src/components/portfolio/modal/EarnInterestModal.tsx
@@ -605,6 +605,7 @@ export default function EarnInterestModal(props: EarnInterestModalProps) {
     address: account?.address ?? '0x',
     token: selectedOption.address,
     chainId: activeChain.id,
+    enabled: isOpen,
   });
 
   useEffect(() => {

--- a/earn/src/components/portfolio/modal/SendCryptoModal.tsx
+++ b/earn/src/components/portfolio/modal/SendCryptoModal.tsx
@@ -184,6 +184,7 @@ export default function SendCryptoModal(props: SendCryptoModalProps) {
     address: account?.address ?? '0x',
     token: selectedOption.address,
     chainId: activeChain.id,
+    enabled: isOpen,
   });
 
   useEffect(() => {

--- a/earn/src/components/portfolio/modal/WithdrawModal.tsx
+++ b/earn/src/components/portfolio/modal/WithdrawModal.tsx
@@ -209,7 +209,7 @@ export default function WithdrawModal(props: WithdrawModalProps) {
   const { refetch: refetchMaxWithdraw, data: maxWithdraw } = useContractRead({
     address: activeKitty?.address,
     abi: KittyABI,
-    enabled: activeKitty != null,
+    enabled: activeKitty != null && account.address !== undefined && isOpen,
     functionName: 'maxWithdraw',
     chainId: activeChain.id,
     args: [account.address] as const,
@@ -218,7 +218,7 @@ export default function WithdrawModal(props: WithdrawModalProps) {
   const { refetch: refetchMaxRedeem, data: maxRedeem } = useContractRead({
     address: activeKitty?.address,
     abi: KittyABI,
-    enabled: activeKitty != null,
+    enabled: activeKitty != null && account.address !== undefined && isOpen,
     functionName: 'maxRedeem',
     chainId: activeChain.id,
     args: [account.address] as const,

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -238,7 +238,7 @@ export default function BorrowPage() {
   useEffect(() => {
     let mounted = true;
     const cachedMarginAccount = cachedMarginAccounts.get(selectedMarginAccountPreview?.address ?? '');
-    if (cachedMarginAccount != null) {
+    if (cachedMarginAccount !== undefined) {
       setSelectedMarginAccount(cachedMarginAccount);
       return;
     }
@@ -270,7 +270,7 @@ export default function BorrowPage() {
   useEffect(() => {
     let mounted = true;
     const cachedMarketInfo = cachedMarketInfos.get(selectedMarginAccount?.address ?? '');
-    if (cachedMarketInfo != null) {
+    if (cachedMarketInfo !== undefined) {
       setSelectedMarketInfo(cachedMarketInfo);
       return;
     }


### PR DESCRIPTION
Building off of #312, this PR adds caching that prevents the unnecessary re-fetching of data for lending pairs. This also saves us a fair bit of outgoing requests and is a great optimization.