### PR TITLE
Switching from block to zero to work cross chain

### DIFF
--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -169,16 +169,17 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
       setNumberOfUsers(cachedResult);
       return;
     }
+    // TODO: move this to a hook
     async function fetchNumberOfUsers() {
       const etherscanRequestLender0 = makeEtherscanRequest(
-        7537163,
+        0,
         selectedLendingPair.kitty0.address,
         ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
         true,
         activeChain
       );
       const etherscanRequestLender1 = makeEtherscanRequest(
-        7537163,
+        0,
         selectedLendingPair.kitty1.address,
         ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
         true,


### PR DESCRIPTION
I am unsure if there are many downsides to not providing a reasonable fromBlock. I would like to know if it has any noticeable effect on the time it takes us to receive a response. If that is the case, we should use more precise numbers, which enables this to work cross-chain for now. We will likely not know for sure if there is much of any effect right now because we aren't fetching too much data, but as this amount grows, the impact may be more noticeable.