### PR TITLE
Fixing modal state updating

### DIFF
--- a/earn/src/components/borrow/GlobalStatsTable.tsx
+++ b/earn/src/components/borrow/GlobalStatsTable.tsx
@@ -2,7 +2,7 @@ import { Display, Text } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
 
 import { RESPONSIVE_BREAKPOINT_XS } from '../../data/constants/Breakpoints';
-import { MarginAccountPreview, MarketInfo } from '../../data/MarginAccount';
+import { MarginAccount, MarketInfo } from '../../data/MarginAccount';
 import { formatTokenAmount, roundPercentage } from '../../util/Numbers';
 
 const STAT_LABEL_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
@@ -47,16 +47,16 @@ const StatContainer = styled.div`
 `;
 
 export type GlobalStatsTableProps = {
-  marginAccountPreview?: MarginAccountPreview;
+  marginAccount?: MarginAccount;
   marketInfo?: MarketInfo;
 };
 
 export default function GlobalStatsTable(props: GlobalStatsTableProps) {
-  const { marginAccountPreview, marketInfo } = props;
-  if (!marginAccountPreview || !marketInfo) {
+  const { marginAccount, marketInfo } = props;
+  if (!marginAccount || !marketInfo) {
     return null;
   }
-  const { token0, token1 } = marginAccountPreview;
+  const { token0, token1 } = marginAccount;
   const lender0TotalSupply = marketInfo.lender0TotalSupply.div(10 ** token0.decimals);
   const lender1TotalSupply = marketInfo.lender1TotalSupply.div(10 ** token1.decimals);
   const lender0TotalBorrows = marketInfo.lender0TotalBorrows.div(10 ** token0.decimals);

--- a/earn/src/components/borrow/modal/AddCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/AddCollateralModal.tsx
@@ -160,10 +160,11 @@ export default function AddCollateralModal(props: AddCollateralModalProps) {
     };
   }, [isOpen, refetchBalance]);
 
-  const resetModal = () => {
+  // Reset collateral amount and token when modal is opened/closed or when the margin account token0 changes
+  useEffect(() => {
     setCollateralAmount('');
     setCollateralToken(marginAccount.token0);
-  };
+  }, [isOpen, marginAccount.token0]);
 
   const tokenOptions = [marginAccount.token0, marginAccount.token1];
 
@@ -188,17 +189,7 @@ export default function AddCollateralModal(props: AddCollateralModalProps) {
   const newCollateralBig = existingCollateralBig.add(collateralAmountBig).div(10 ** collateralToken.decimals);
 
   return (
-    <Modal
-      isOpen={isOpen}
-      title='Add Collateral'
-      setIsOpen={(open: boolean) => {
-        setIsOpen(open);
-        if (!open) {
-          resetModal();
-        }
-      }}
-      maxHeight='650px'
-    >
+    <Modal isOpen={isOpen} title='Add Collateral' setIsOpen={setIsOpen} maxHeight='650px'>
       <div className='flex flex-col items-center justify-center gap-8 w-full mt-2'>
         <div className='flex flex-col gap-1 w-full'>
           <div className='flex flex-row justify-between mb-1'>

--- a/earn/src/components/borrow/modal/BorrowModal.tsx
+++ b/earn/src/components/borrow/modal/BorrowModal.tsx
@@ -146,10 +146,12 @@ export default function BorrowModal(props: BorrowModalProps) {
     chainId: activeChain.id,
   });
 
-  const resetModal = () => {
+  // Reset borrow amount and token when modal is opened/closed
+  // or when the margin account token0 changes
+  useEffect(() => {
     setBorrowAmount('');
     setBorrowToken(marginAccount.token0);
-  };
+  }, [isOpen, marginAccount.token0]);
 
   const tokenOptions = [marginAccount.token0, marginAccount.token1];
 
@@ -172,17 +174,7 @@ export default function BorrowModal(props: BorrowModalProps) {
   }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      title='Borrow'
-      setIsOpen={(open: boolean) => {
-        setIsOpen(open);
-        if (!open) {
-          resetModal();
-        }
-      }}
-      maxHeight='650px'
-    >
+    <Modal isOpen={isOpen} title='Borrow' setIsOpen={setIsOpen} maxHeight='650px'>
       <div className='flex flex-col items-center justify-center gap-8 w-full mt-2'>
         <div className='flex flex-col gap-1 w-full'>
           <Text size='M' weight='bold'>

--- a/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
+++ b/earn/src/components/borrow/modal/RemoveCollateralModal.tsx
@@ -151,10 +151,11 @@ export default function RemoveCollateralModal(props: RemoveCollateralModalProps)
 
   const { address: userAddress } = useAccount();
 
-  const resetModal = () => {
+  // Reset the collateral amount and token when modal is opened/closed or when the margin account token0 changes
+  useEffect(() => {
     setCollateralAmount('');
     setCollateralToken(marginAccount.token0);
-  };
+  }, [isOpen, marginAccount.token0]);
 
   const tokenOptions = [marginAccount.token0, marginAccount.token1];
 
@@ -181,17 +182,7 @@ export default function RemoveCollateralModal(props: RemoveCollateralModalProps)
   }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      title='Remove Collateral'
-      setIsOpen={(open: boolean) => {
-        setIsOpen(open);
-        if (!open) {
-          resetModal();
-        }
-      }}
-      maxHeight='650px'
-    >
+    <Modal isOpen={isOpen} title='Remove Collateral' setIsOpen={setIsOpen} maxHeight='650px'>
       <div className='flex flex-col items-center justify-center gap-8 w-full mt-2'>
         <div className='flex flex-col gap-1 w-full'>
           <Text size='M' weight='bold'>

--- a/earn/src/components/borrow/modal/RepayModal.tsx
+++ b/earn/src/components/borrow/modal/RepayModal.tsx
@@ -158,10 +158,11 @@ export default function RepayModal(props: RepayModalProps) {
 
   const { address: userAddress } = useAccount();
 
-  const resetModal = () => {
+  // Reset repay amount and token when modal is opened/closed or when the margin account token0 changes
+  useEffect(() => {
     setRepayAmount('');
     setRepayToken(marginAccount.token0);
-  };
+  }, [isOpen, marginAccount.token0]);
 
   const tokenOptions = [marginAccount.token0, marginAccount.token1];
 
@@ -188,17 +189,7 @@ export default function RepayModal(props: RepayModalProps) {
   }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      title='Repay'
-      setIsOpen={(open: boolean) => {
-        setIsOpen(open);
-        if (!open) {
-          resetModal();
-        }
-      }}
-      maxHeight='650px'
-    >
+    <Modal isOpen={isOpen} title='Repay' setIsOpen={setIsOpen} maxHeight='650px'>
       <div className='flex flex-col items-center justify-center gap-8 w-full mt-2'>
         <div className='flex flex-col gap-1 w-full'>
           <div className='flex flex-row justify-between mb-1'>

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import { secondsInYear } from 'date-fns';
-import { ContractCallContext, ContractCallResults, Multicall } from 'ethereum-multicall';
+import { ContractCallContext, Multicall } from 'ethereum-multicall';
 import { ethers } from 'ethers';
 import JSBI from 'jsbi';
 import { FeeTier, NumericFeeTierToEnum } from 'shared/lib/data/FeeTier';
@@ -9,10 +9,9 @@ import { Address, Chain } from 'wagmi';
 import KittyLensABI from '../assets/abis/KittyLens.json';
 import MarginAccountABI from '../assets/abis/MarginAccount.json';
 import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
-import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
 import { makeEtherscanRequest } from '../util/Etherscan';
-import { convertBigNumbers } from '../util/Multicall';
+import { ContractCallReturnContextEntries, convertBigNumbers } from '../util/Multicall';
 import { toBig } from '../util/Numbers';
 import {
   ALOE_II_BORROWER_LENS_ADDRESS,
@@ -22,7 +21,6 @@ import {
 } from './constants/Addresses';
 import { TOPIC0_CREATE_BORROWER_EVENT } from './constants/Signatures';
 import { Token } from './Token';
-import { getToken } from './TokenData';
 
 export type UniswapPosition = {
   lower: number;
@@ -111,16 +109,17 @@ export type UniswapPoolInfo = {
   fee: number;
 };
 
-export async function fetchMarginAccountPreviews(
+export async function fetchMarginAccounts(
   chain: Chain,
   provider: ethers.providers.BaseProvider,
   userAddress: string,
   uniswapPoolDataMap: Map<string, UniswapPoolInfo>
-): Promise<MarginAccountPreview[]> {
+): Promise<MarginAccount[]> {
   const multicall = new Multicall({ ethersProvider: provider, tryAggregate: true });
   const marginAccountsAddresses = await getMarginAccountsForUser(chain, userAddress, provider);
-  let contractCallContext: ContractCallContext[] = [];
+  const marginAccountCallContext: ContractCallContext[] = [];
 
+  // Fetch all the data for the margin accounts
   marginAccountsAddresses.forEach(({ address: accountAddress, uniswapPool }) => {
     const uniswapPoolInfo = uniswapPoolDataMap.get(`0x${uniswapPool}`) ?? null;
 
@@ -131,9 +130,38 @@ export async function fetchMarginAccountPreviews(
     const feeTier = NumericFeeTierToEnum(uniswapPoolInfo.fee);
 
     if (!token0 || !token1) return;
-
-    contractCallContext.push({
-      reference: accountAddress,
+    // Fetching the data for the margin account using three contracts
+    marginAccountCallContext.push({
+      reference: `${accountAddress}-account`,
+      contractAddress: accountAddress,
+      abi: MarginAccountABI,
+      calls: [
+        {
+          reference: 'lender0',
+          methodName: 'LENDER0',
+          methodParameters: [],
+        },
+        {
+          reference: 'lender1',
+          methodName: 'LENDER1',
+          methodParameters: [],
+        },
+      ],
+    });
+    marginAccountCallContext.push({
+      reference: `${accountAddress}-oracle`,
+      contractAddress: ALOE_II_ORACLE,
+      abi: VolatilityOracleABI,
+      calls: [
+        {
+          reference: 'consult',
+          methodName: 'consult',
+          methodParameters: [uniswapPool],
+        },
+      ],
+    });
+    marginAccountCallContext.push({
+      reference: `${accountAddress}-lens`,
       contractAddress: ALOE_II_BORROWER_LENS_ADDRESS,
       abi: MarginAccountLensABI,
       calls: [
@@ -163,17 +191,32 @@ export async function fetchMarginAccountPreviews(
     });
   });
 
-  const results = (await multicall.call(contractCallContext)).results;
+  const marginAccountResults = (await multicall.call(marginAccountCallContext)).results;
 
-  let marginAccounts: MarginAccountPreview[] = [];
+  const correspondingMarginAccountResults: Map<string, ContractCallReturnContextEntries> = new Map();
 
-  Object.values(results).forEach((value) => {
-    const contractResults = value.callsReturnContext;
-    const updatedReturnContext = convertBigNumbers(contractResults);
-    const { feeTier, token0, token1, accountAddress, uniswapPool } = value.originalContractCallContext.context;
-    const assetsData = updatedReturnContext[0].returnValues;
-    const liabilitiesData = updatedReturnContext[1].returnValues;
-    const healthData = updatedReturnContext[2].returnValues;
+  // Convert the results into a map of account address to the results
+  Object.entries(marginAccountResults).forEach(([key, value]) => {
+    const entryAccountAddress = key.split('-')[0];
+    const entryType = key.split('-')[1];
+    const existingValue = correspondingMarginAccountResults.get(entryAccountAddress);
+    if (existingValue) {
+      existingValue[entryType] = value;
+      correspondingMarginAccountResults.set(entryAccountAddress, existingValue);
+    } else {
+      correspondingMarginAccountResults.set(entryAccountAddress, { [entryType]: value });
+    }
+  });
+
+  const marginAccounts: MarginAccount[] = [];
+
+  correspondingMarginAccountResults.forEach((value) => {
+    const { lens: lensResults, account: accountResults, oracle: oracleResults } = value;
+    const lensReturnContexts = convertBigNumbers(lensResults.callsReturnContext);
+    const { feeTier, token0, token1, accountAddress, uniswapPool } = lensResults.originalContractCallContext.context;
+    const assetsData = lensReturnContexts[0].returnValues;
+    const liabilitiesData = lensReturnContexts[1].returnValues;
+    const healthData = lensReturnContexts[2].returnValues;
     const healthData0 = Big(healthData[0].toString());
     const healthData1 = Big(healthData[1].toString());
     const health = healthData0.lt(healthData1) ? healthData0 : healthData1;
@@ -199,17 +242,26 @@ export async function fetchMarginAccountPreviews(
         .div(10 ** token1.decimals)
         .toNumber(),
     };
-    marginAccounts.push({
+    const lender0 = accountResults.callsReturnContext[0].returnValues[0];
+    const lender1 = accountResults.callsReturnContext[1].returnValues[0];
+    const oracleReturnValues = convertBigNumbers(oracleResults.callsReturnContext)[0].returnValues;
+    const marginAccount: MarginAccount = {
       address: accountAddress,
-      uniswapPool,
-      token0,
-      token1,
-      feeTier,
-      assets,
-      liabilities,
-      health: health.div(1e9).toNumber() / 1e9,
-    });
+      uniswapPool: uniswapPool,
+      feeTier: feeTier,
+      assets: assets,
+      liabilities: liabilities,
+      health: health.toNumber(),
+      token0: token0,
+      token1: token1,
+      lender0: lender0,
+      lender1: lender1,
+      sqrtPriceX96: toBig(oracleReturnValues[0]),
+      iv: oracleReturnValues[1].div(1e9).toNumber() / 1e9,
+    };
+    marginAccounts.push(marginAccount);
   });
+
   return marginAccounts;
 }
 
@@ -265,105 +317,5 @@ export async function fetchMarketInfoFor(
     lender1TotalSupply: lender1TotalSupply,
     lender0TotalBorrows: lender0TotalBorrows,
     lender1TotalBorrows: lender1TotalBorrows,
-  };
-}
-
-export async function fetchMarginAccount(
-  accountAddress: string,
-  chain: Chain,
-  provider: ethers.providers.BaseProvider,
-  marginAccountAddress: string
-): Promise<{
-  marginAccount: MarginAccount;
-}> {
-  const multicall = new Multicall({ ethersProvider: provider, tryAggregate: true });
-
-  const contractCallContext: ContractCallContext[] = [
-    {
-      reference: 'marginAccountContract',
-      contractAddress: marginAccountAddress,
-      abi: MarginAccountABI,
-      calls: [
-        { reference: 'token0', methodName: 'TOKEN0', methodParameters: [] },
-        { reference: 'token1', methodName: 'TOKEN1', methodParameters: [] },
-        { reference: 'lender0', methodName: 'LENDER0', methodParameters: [] },
-        { reference: 'lender1', methodName: 'LENDER1', methodParameters: [] },
-        { reference: 'uniswapPool', methodName: 'UNISWAP_POOL', methodParameters: [] },
-      ],
-    },
-    {
-      reference: 'marginAccountLensContract',
-      contractAddress: ALOE_II_BORROWER_LENS_ADDRESS,
-      abi: MarginAccountLensABI,
-      calls: [
-        { reference: 'assets', methodName: 'getAssets', methodParameters: [marginAccountAddress] },
-        { reference: 'liabilities', methodName: 'getLiabilities', methodParameters: [marginAccountAddress, true] },
-        { reference: 'health', methodName: 'getHealth', methodParameters: [accountAddress, true] },
-      ],
-    },
-  ];
-
-  const results: ContractCallResults = await multicall.call(contractCallContext);
-  const marginAccountContractResults = results.results['marginAccountContract'].callsReturnContext;
-  const marginAccountLensContractResults = results.results['marginAccountLensContract'].callsReturnContext;
-  const updatedLensReturnContext = convertBigNumbers(marginAccountLensContractResults);
-  const token0 = getToken(chain.id, marginAccountContractResults[0].returnValues[0]);
-  const token1 = getToken(chain.id, marginAccountContractResults[1].returnValues[0]);
-  const lender0 = marginAccountContractResults[2].returnValues[0];
-  const lender1 = marginAccountContractResults[3].returnValues[0];
-  const uniswapPool = marginAccountContractResults[4].returnValues[0];
-  const assetsData = updatedLensReturnContext[0].returnValues;
-  const liabilitiesData = updatedLensReturnContext[1].returnValues;
-  const healthData = updatedLensReturnContext[2].returnValues;
-
-  const uniswapPoolContract = new ethers.Contract(uniswapPool, UniswapV3PoolABI, provider);
-  const volatilityOracleContract = new ethers.Contract(ALOE_II_ORACLE, VolatilityOracleABI, provider);
-  const [feeTier, oracleResult] = await Promise.all([
-    uniswapPoolContract.fee(),
-    volatilityOracleContract.consult(uniswapPool),
-  ]);
-
-  const assets: Assets = {
-    token0Raw: Big(assetsData[0].toString())
-      .div(10 ** token0.decimals)
-      .toNumber(),
-    token1Raw: Big(assetsData[1].toString())
-      .div(10 ** token1.decimals)
-      .toNumber(),
-    uni0: Big(assetsData[4].toString())
-      .div(10 ** token0.decimals)
-      .toNumber(),
-    uni1: Big(assetsData[5].toString())
-      .div(10 ** token1.decimals)
-      .toNumber(),
-  };
-  const liabilities: Liabilities = {
-    amount0: Big(liabilitiesData[0].toString())
-      .div(10 ** token0.decimals)
-      .toNumber(),
-    amount1: Big(liabilitiesData[1].toString())
-      .div(10 ** token1.decimals)
-      .toNumber(),
-  };
-
-  const healthData0 = Big(healthData[0].toString());
-  const healthData1 = Big(healthData[1].toString());
-  const health = healthData0.lt(healthData1) ? healthData0 : healthData1;
-
-  return {
-    marginAccount: {
-      address: marginAccountAddress,
-      uniswapPool: uniswapPool,
-      token0: token0,
-      token1: token1,
-      feeTier: NumericFeeTierToEnum(feeTier),
-      assets: assets,
-      liabilities: liabilities,
-      sqrtPriceX96: toBig(oracleResult[0]),
-      health: health.div(1e9).toNumber() / 1e9,
-      lender0: lender0,
-      lender1: lender1,
-      iv: oracleResult[1].div(1e9).toNumber() / 1e9,
-    },
   };
 }

--- a/earn/src/util/Multicall.ts
+++ b/earn/src/util/Multicall.ts
@@ -1,5 +1,9 @@
-import { CallReturnContext } from 'ethereum-multicall';
+import { CallReturnContext, ContractCallReturnContext } from 'ethereum-multicall';
 import { BigNumber } from 'ethers';
+
+export type ContractCallReturnContextEntries = {
+  [key: string]: ContractCallReturnContext;
+};
 
 export function convertBigNumbers(callReturnContexts: CallReturnContext[]): CallReturnContext[] {
   return callReturnContexts.map((callReturnContext) => {


### PR DESCRIPTION
Builds off of #321. Currently, no logic updates the selectedToken to match the selected margin account, leading to less-than-desirable results, such as having a selectedToken that isn't even a part of the selected pair. With this new logic, there is also no need to reset the modal explicitly on close as we did before.