### PR TITLE
Fixing scientific notation breaking decimals

### DIFF
--- a/earn/src/components/borrow/modal/RepayModal.tsx
+++ b/earn/src/components/borrow/modal/RepayModal.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState, useMemo, useEffect } from 'react';
 
 import { SendTransactionResult, FetchBalanceResult } from '@wagmi/core';
+import Big from 'big.js';
 import { ethers, BigNumber } from 'ethers';
 import { FilledStylizedButton } from 'shared/lib/components/common/Buttons';
 import { BaseMaxButton } from 'shared/lib/components/common/Input';
@@ -25,7 +26,7 @@ import useAllowance from '../../../data/hooks/UseAllowance';
 import useAllowanceWrite from '../../../data/hooks/UseAllowanceWrite';
 import { MarginAccount } from '../../../data/MarginAccount';
 import { Token } from '../../../data/Token';
-import { formatNumberInput, removeScientificNotation, truncateDecimals } from '../../../util/Numbers';
+import { formatNumberInput, truncateDecimals } from '../../../util/Numbers';
 import { attemptToInferPermitDomain, EIP2612Domain, getErc2612Signature } from '../../../util/Permit';
 import TokenAmountSelectInput from '../../portfolio/TokenAmountSelectInput';
 
@@ -136,10 +137,7 @@ function RepayButton(props: RepayButtonProps) {
 
   // MARK: Preparing data that's necessary to figure out button state -------------------------------------------------
   const existingLiability = marginAccount.liabilities[lender === marginAccount.lender0 ? 'amount0' : 'amount1'];
-  const bigExistingLiability = ethers.utils.parseUnits(
-    removeScientificNotation(existingLiability.toString(), repayToken.decimals),
-    repayToken.decimals
-  );
+  const bigExistingLiability = BigNumber.from(new Big(existingLiability).mul(10 ** repayToken.decimals).toFixed(0));
   const bigRepayAmount = ethers.utils.parseUnits(repayAmount === '' ? '0' : repayAmount, repayToken.decimals);
 
   // MARK: Determining button state -----------------------------------------------------------------------------------
@@ -327,10 +325,7 @@ export default function RepayModal(props: RepayModalProps) {
     repayToken.address === marginAccount.token0.address
       ? marginAccount.liabilities.amount0
       : marginAccount.liabilities.amount1;
-  const bigExistingLiability = ethers.utils.parseUnits(
-    removeScientificNotation(existingLiability.toString(), repayToken.decimals),
-    repayToken.decimals
-  );
+  const bigExistingLiability = BigNumber.from(new Big(existingLiability).mul(10 ** repayToken.decimals).toFixed(0));
   const bigRepayAmount = ethers.utils.parseUnits(repayAmount === '' ? '0' : repayAmount, repayToken.decimals);
   const bigRemainingLiability = bigExistingLiability.sub(bigRepayAmount);
 

--- a/earn/src/components/borrow/modal/RepayModal.tsx
+++ b/earn/src/components/borrow/modal/RepayModal.tsx
@@ -25,7 +25,7 @@ import useAllowance from '../../../data/hooks/UseAllowance';
 import useAllowanceWrite from '../../../data/hooks/UseAllowanceWrite';
 import { MarginAccount } from '../../../data/MarginAccount';
 import { Token } from '../../../data/Token';
-import { formatNumberInput, truncateDecimals } from '../../../util/Numbers';
+import { formatNumberInput, removeScientificNotation, truncateDecimals } from '../../../util/Numbers';
 import { attemptToInferPermitDomain, EIP2612Domain, getErc2612Signature } from '../../../util/Permit';
 import TokenAmountSelectInput from '../../portfolio/TokenAmountSelectInput';
 
@@ -136,7 +136,10 @@ function RepayButton(props: RepayButtonProps) {
 
   // MARK: Preparing data that's necessary to figure out button state -------------------------------------------------
   const existingLiability = marginAccount.liabilities[lender === marginAccount.lender0 ? 'amount0' : 'amount1'];
-  const bigExistingLiability = ethers.utils.parseUnits(existingLiability.toString(), repayToken.decimals);
+  const bigExistingLiability = ethers.utils.parseUnits(
+    removeScientificNotation(existingLiability.toString(), repayToken.decimals),
+    repayToken.decimals
+  );
   const bigRepayAmount = ethers.utils.parseUnits(repayAmount === '' ? '0' : repayAmount, repayToken.decimals);
 
   // MARK: Determining button state -----------------------------------------------------------------------------------
@@ -324,7 +327,10 @@ export default function RepayModal(props: RepayModalProps) {
     repayToken.address === marginAccount.token0.address
       ? marginAccount.liabilities.amount0
       : marginAccount.liabilities.amount1;
-  const bigExistingLiability = ethers.utils.parseUnits(existingLiability.toString(), repayToken.decimals);
+  const bigExistingLiability = ethers.utils.parseUnits(
+    removeScientificNotation(existingLiability.toString(), repayToken.decimals),
+    repayToken.decimals
+  );
   const bigRepayAmount = ethers.utils.parseUnits(repayAmount === '' ? '0' : repayAmount, repayToken.decimals);
   const bigRemainingLiability = bigExistingLiability.sub(bigRepayAmount);
 

--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -226,3 +226,11 @@ export function getDecimalPlaces(value: string): number {
   }
   return value.length - decimalIndex - 1;
 }
+
+export function removeScientificNotation(value: string, maxDecimals: number): string {
+  if (value.indexOf('e') === -1) {
+    return value;
+  }
+  const asNumber = Number(value);
+  return truncateDecimals(asNumber.toFixed(maxDecimals), maxDecimals);
+}

--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -226,11 +226,3 @@ export function getDecimalPlaces(value: string): number {
   }
   return value.length - decimalIndex - 1;
 }
-
-export function removeScientificNotation(value: string, maxDecimals: number): string {
-  if (value.indexOf('e') === -1) {
-    return value;
-  }
-  const asNumber = Number(value);
-  return truncateDecimals(asNumber.toFixed(maxDecimals), maxDecimals);
-}


### PR DESCRIPTION
Fixing a bug that caused the repay modal to crash when the amount was small enough, and javascript decided to represent it in scientific notation in the toString result. To fix this, I added a function that removes scientific notation from a number (if a number is in scientific notation) and clamps that number to no more than a certain amount of decimals provided as input.