### PR TITLE
skip to the markets page on earn

### DIFF
--- a/earn/src/App.tsx
+++ b/earn/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect } from 'react';
 
 import { ApolloClient, InMemoryCache, HttpLink, gql } from '@apollo/react-hooks';
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Route, Routes, Navigate, useNavigate } from 'react-router-dom';
 import BetaBanner from 'shared/lib/components/banner/BetaBanner';
 import Footer from 'shared/lib/components/common/Footer';
 import { Text } from 'shared/lib/components/common/Typography';
@@ -61,6 +61,7 @@ function AppBodyWrapper() {
   const { activeChain, setActiveChain } = React.useContext(ChainContext);
   const account = useAccount();
   const network = useNetwork();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (network.chain !== undefined && network.chain !== activeChain) {
@@ -96,6 +97,7 @@ function AppBodyWrapper() {
         account={account}
         setIsOpen={() => setIsWelcomeModalOpen(false)}
         onAcknowledged={() => setLocalStorageBoolean('hasSeenWelcomeModal', true)}
+        onSkip={() => navigate('/markets')}
       />
     </AppBody>
   );

--- a/shared/src/components/common/WelcomeModal.tsx
+++ b/shared/src/components/common/WelcomeModal.tsx
@@ -17,10 +17,11 @@ export type WelcomeModalProps = {
   account?: GetAccountResult<Provider>;
   setIsOpen: (open: boolean) => void;
   onAcknowledged: () => void;
+  onSkip?: () => void;
 };
 
 export default function WelcomeModal(props: WelcomeModalProps) {
-  const { isOpen, activeChain, checkboxes, account, setIsOpen, onAcknowledged } = props;
+  const { isOpen, activeChain, checkboxes, account, setIsOpen, onAcknowledged, onSkip } = props;
 
   return (
     <Modal isOpen={isOpen} setIsOpen={setIsOpen} title='Welcome!'>
@@ -39,6 +40,7 @@ export default function WelcomeModal(props: WelcomeModalProps) {
             onClick={() => {
               onAcknowledged();
               setIsOpen(false);
+              onSkip?.();
             }}
           >
             Skip for now


### PR DESCRIPTION
When the user clicks "skip for now" on the welcome modal on earn, they are brought to the markets page.