### PR TITLE
Fix remove liquidity percentage not snapping on blur

### DIFF
--- a/prime/src/components/borrow/actions/UniswapRemoveLiquidityActionCard.tsx
+++ b/prime/src/components/borrow/actions/UniswapRemoveLiquidityActionCard.tsx
@@ -53,7 +53,7 @@ export default function UniswapRemoveLiquidityActionCard(props: ActionCardProps)
     }
     // TODO: refactor this to have exhaustive dependency list
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accountState]);
+  }, [accountState, userInputFields]);
 
   let selectedOption: DropdownOption<number> | undefined = undefined;
   let selectedPosition: UniswapPosition | undefined = undefined;


### PR DESCRIPTION
I noticed that there was quite a bit of delay from when I typed in a number on the remove liquidity action card (and then clicked off the input) and when it formatted the number. In the past, this update happened immediately, but this logic must have gotten removed at some point. I fixed this issue by adding the `userInputFields` to the list of dependencies. It is a very small fix, but it makes a huge difference in UX.