### PR TITLE
Passing uniswap positions into liquidation threshold calculations

### DIFF
--- a/earn/src/components/borrow/BorrowMetrics.tsx
+++ b/earn/src/components/borrow/BorrowMetrics.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { computeLiquidationThresholds, getAssets, sqrtRatioToPrice } from '../../data/BalanceSheet';
 import { RESPONSIVE_BREAKPOINT_MD, RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
 import { MarginAccount } from '../../data/MarginAccount';
+import { UniswapPosition } from '../../data/Uniswap';
 import { formatTokenAmount } from '../../util/Numbers';
 
 const BORROW_TITLE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
@@ -125,10 +126,11 @@ export type BorrowMetricsProps = {
   marginAccount?: MarginAccount;
   dailyInterest0: number;
   dailyInterest1: number;
+  uniswapPositions: readonly UniswapPosition[];
 };
 
 export function BorrowMetrics(props: BorrowMetricsProps) {
-  const { marginAccount, dailyInterest0, dailyInterest1 } = props;
+  const { marginAccount, dailyInterest0, dailyInterest1, uniswapPositions } = props;
 
   const maxSafeCollateralFall = useMemo(() => {
     if (!marginAccount) return null;
@@ -136,7 +138,7 @@ export function BorrowMetrics(props: BorrowMetricsProps) {
     const { lowerSqrtRatio, upperSqrtRatio, minSqrtRatio, maxSqrtRatio } = computeLiquidationThresholds(
       marginAccount.assets,
       marginAccount.liabilities,
-      [], // TODO: We should actually fetch Uniswap positions
+      uniswapPositions,
       marginAccount.sqrtPriceX96,
       marginAccount.iv,
       marginAccount.token0.decimals,
@@ -151,7 +153,7 @@ export function BorrowMetrics(props: BorrowMetricsProps) {
 
     const assets = getAssets(
       marginAccount.assets,
-      [], // TODO: We should actually fetch Uniswap positions
+      uniswapPositions,
       marginAccount.sqrtPriceX96,
       lowerSqrtRatio,
       upperSqrtRatio,
@@ -187,7 +189,7 @@ export function BorrowMetrics(props: BorrowMetricsProps) {
     // Since we don't know whether the user is thinking in terms of "X per Y" or "Y per X",
     // we return the minimum. Error on the side of being too conservative.
     return Math.min(percentChange0, percentChange1);
-  }, [marginAccount]);
+  }, [marginAccount, uniswapPositions]);
 
   if (!marginAccount) return null;
 

--- a/earn/src/data/BalanceSheet.ts
+++ b/earn/src/data/BalanceSheet.ts
@@ -236,7 +236,7 @@ export type LiquidationThresholds = {
 export function computeLiquidationThresholds(
   assets: Assets,
   liabilities: Liabilities,
-  uniswapPositions: UniswapPosition[],
+  uniswapPositions: readonly UniswapPosition[],
   sqrtPriceX96: Big,
   iv: number,
   token0Decimals: number,

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -6,7 +6,7 @@ import { ethers } from 'ethers';
 import JSBI from 'jsbi';
 
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
-import { convertBigNumbers } from '../util/Multicall';
+import { convertBigNumbersForReturnContexts } from '../util/Multicall';
 import { toBig } from '../util/Numbers';
 import { BIGQ96, Q96 } from './constants/Values';
 
@@ -179,7 +179,7 @@ export async function fetchUniswapPositions(
     });
   });
   const results = (await multicall.call(contractCallContext)).results;
-  const updatedReturnContext = convertBigNumbers(results['uniswapV3Pool'].callsReturnContext);
+  const updatedReturnContext = convertBigNumbersForReturnContexts(results['uniswapV3Pool'].callsReturnContext);
 
   const fetchedUniswapPositions = new Map<string, UniswapPosition>();
   priors.forEach((prior, i) => {
@@ -212,7 +212,7 @@ export async function fetchUniswapPoolBasics(
   ];
 
   const results = (await multicall.call(contractCallContext)).results;
-  const updatedReturnContext = convertBigNumbers(results['uniswapV3Pool'].callsReturnContext);
+  const updatedReturnContext = convertBigNumbersForReturnContexts(results['uniswapV3Pool'].callsReturnContext);
   const slot0 = updatedReturnContext[0].returnValues;
   const tickSpacing = updatedReturnContext[1].returnValues;
 

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -476,6 +476,7 @@ export default function BorrowPage() {
               marginAccount={selectedMarginAccount}
               dailyInterest0={dailyInterest0}
               dailyInterest1={dailyInterest1}
+              uniswapPositions={uniswapPositions}
             />
           </MetricsContainer>
           <StatsContainer>


### PR DESCRIPTION
As the title suggests, I am passing the uniswap positions into the calculations for the liquidation thresholds to get a more accurate result. Additionally, I am fixing a few bugs along the way.