### PR TITLE
Fixing bug that caused prime to crash

### DIFF
--- a/prime/src/pages/BorrowActionsPage.tsx
+++ b/prime/src/pages/BorrowActionsPage.tsx
@@ -301,8 +301,12 @@ export default function BorrowActionsPage() {
     let mounted = true;
     async function fetchMarketInfo() {
       if (!lenderLensContract || !marginAccount) return;
-      const marketInfo = await fetchMarketInfoFor(lenderLensContract, marginAccount.lender0, marginAccount.lender1);
-      if (mounted) setMarketInfo(marketInfo);
+      const fetchedMarketInfo = await fetchMarketInfoFor(
+        lenderLensContract,
+        marginAccount.lender0,
+        marginAccount.lender1
+      );
+      if (mounted) setMarketInfo(fetchedMarketInfo);
     }
     fetchMarketInfo();
     return () => {
@@ -478,15 +482,15 @@ export default function BorrowActionsPage() {
   if (marketInfo && isShowingHypothetical) {
     utilization0 =
       1 -
-      hypotheticalState.availableForBorrow.amount0 /
-        marketInfo.lender0TotalAssets.div(10 ** token0.decimals).toNumber();
+        hypotheticalState.availableForBorrow.amount0 /
+          marketInfo.lender0TotalAssets.div(10 ** token0.decimals).toNumber() || 0;
     utilization1 =
       1 -
-      hypotheticalState.availableForBorrow.amount1 /
-        marketInfo.lender1TotalAssets.div(10 ** token1.decimals).toNumber();
+        hypotheticalState.availableForBorrow.amount1 /
+          marketInfo.lender1TotalAssets.div(10 ** token1.decimals).toNumber() || 0;
   }
-  const apr0 = yieldPerSecondToAPR(RateModel.computeYieldPerSecond(utilization0 ?? 0));
-  const apr1 = yieldPerSecondToAPR(RateModel.computeYieldPerSecond(utilization1 ?? 0));
+  const apr0 = yieldPerSecondToAPR(RateModel.computeYieldPerSecond(utilization0 || 0));
+  const apr1 = yieldPerSecondToAPR(RateModel.computeYieldPerSecond(utilization1 || 0));
 
   return (
     <BodyWrapper>


### PR DESCRIPTION
Fixing a bug that caused prime to crash when there was no utilization. This happened because we used a nullish coalescing operator (`??`) instead of a logical or (`||`). The reason this matters, in this case, is that the value that was causing us trouble, `NaN`, is not null or undefined and thus is not considered nullish. Therefore, instead of defaulting the value of zero, `NaN` was kept. However, since `NaN` is considered falsy, the value would default to zero, as it should. Moreover, I also added additional logic at the source of the `NaN`, which happened due to a division by zero, so that it should no longer produce a `NaN` value going forward. With that said, I decided to be extra cautious and still switched from a nullish coalescing operator in this case to a logical or just-in-case. I also renamed a variable so that we didn't shadow the state variable.