### PR TITLE
Util function to avoid mistakes+overflows when fetching chain data

### DIFF
--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -1,5 +1,4 @@
 import { AxiosResponse } from 'axios';
-import Big from 'big.js';
 import { ContractCallContext, Multicall } from 'ethereum-multicall';
 import { ethers } from 'ethers';
 import { FeeTier, NumericFeeTierToEnum } from 'shared/lib/data/FeeTier';
@@ -12,6 +11,7 @@ import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
 import { makeEtherscanRequest } from '../util/Etherscan';
 import { ContractCallReturnContextEntries, convertBigNumbersForReturnContexts } from '../util/Multicall';
+import { toImpreciseNumber } from '../util/Numbers';
 import { ALOE_II_FACTORY_ADDRESS, ALOE_II_KITTY_LENS_ADDRESS, ALOE_II_ORACLE } from './constants/Addresses';
 import { Kitty } from './Kitty';
 import { Token } from './Token';
@@ -180,21 +180,21 @@ export async function getAvailableLendingPairs(
       token1
     );
 
-    const interestRate0 = new Big(basics0[1].toString());
-    const interestRate1 = new Big(basics1[1].toString());
+    const interestRate0 = toImpreciseNumber(basics0[1], 12);
+    const interestRate1 = toImpreciseNumber(basics1[1], 12);
 
-    const utilization0 = new Big(basics0[2].toString()).div(10 ** 18).toNumber();
-    const utilization1 = new Big(basics1[2].toString()).div(10 ** 18).toNumber();
+    const utilization0 = toImpreciseNumber(basics0[2], 18);
+    const utilization1 = toImpreciseNumber(basics1[2], 18);
 
-    const inventory0 = new Big(basics0[3].toString()).div(10 ** token0.decimals).toNumber();
-    const inventory1 = new Big(basics1[3].toString()).div(10 ** token1.decimals).toNumber();
+    const inventory0 = toImpreciseNumber(basics0[3], token0.decimals);
+    const inventory1 = toImpreciseNumber(basics1[3], token1.decimals);
 
-    const totalSupply0 = new Big(basics0[5].toString()).div(10 ** kitty0.decimals).toNumber();
-    const totalSupply1 = new Big(basics1[5].toString()).div(10 ** kitty1.decimals).toNumber();
+    const totalSupply0 = toImpreciseNumber(basics0[5], kitty0.decimals);
+    const totalSupply1 = toImpreciseNumber(basics1[5], kitty1.decimals);
 
     // SupplyAPY = Utilization * (1 - reservePercentage) * BorrowAPY
-    const APY0 = utilization0 * (1 - 1 / 8) * (interestRate0.div(10 ** 12).toNumber() ** (365 * 24 * 60 * 60) - 1.0);
-    const APY1 = utilization1 * (1 - 1 / 8) * (interestRate1.div(10 ** 12).toNumber() ** (365 * 24 * 60 * 60) - 1.0);
+    const APY0 = utilization0 * (1 - 1 / 8) * (interestRate0 ** (365 * 24 * 60 * 60) - 1.0);
+    const APY1 = utilization1 * (1 - 1 / 8) * (interestRate1 ** (365 * 24 * 60 * 60) - 1.0);
 
     let IV = oracleResult[1].div(1e9).toNumber() / 1e9;
     // Annualize it
@@ -244,10 +244,10 @@ export async function getLendingPairBalances(
     kitty0Contract.underlyingBalance(userAddress),
     kitty1Contract.underlyingBalance(userAddress),
   ]);
-  const token0Balance = new Big(token0BalanceBig.toString()).div(10 ** token0.decimals).toNumber();
-  const token1Balance = new Big(token1BalanceBig.toString()).div(10 ** token1.decimals).toNumber();
-  const kitty0Balance = new Big(kitty0BalanceBig.toString()).div(10 ** token0.decimals).toNumber();
-  const kitty1Balance = new Big(kitty1BalanceBig.toString()).div(10 ** token1.decimals).toNumber();
+  const token0Balance = toImpreciseNumber(token0BalanceBig, token0.decimals);
+  const token1Balance = toImpreciseNumber(token1BalanceBig, token1.decimals);
+  const kitty0Balance = toImpreciseNumber(kitty0BalanceBig, token0.decimals);
+  const kitty1Balance = toImpreciseNumber(kitty1BalanceBig, token1.decimals);
   return {
     token0Balance,
     token1Balance,

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -226,17 +226,17 @@ export async function fetchMarginAccounts(
     const oracleReturnValues = convertBigNumbersForReturnContexts(oracleResults.callsReturnContext)[0].returnValues;
     const marginAccount: MarginAccount = {
       address: accountAddress,
-      uniswapPool: uniswapPool,
-      feeTier: feeTier,
-      assets: assets,
-      liabilities: liabilities,
-      health: health,
-      token0: token0,
-      token1: token1,
-      lender0: lender0,
-      lender1: lender1,
       sqrtPriceX96: toBig(oracleReturnValues[0]),
       iv: toImpreciseNumber(oracleReturnValues[1], 18),
+      uniswapPool,
+      feeTier,
+      assets,
+      liabilities,
+      health,
+      token0,
+      token1,
+      lender0,
+      lender1,
     };
     marginAccounts.push(marginAccount);
   });
@@ -276,9 +276,9 @@ export async function fetchMarketInfoFor(
   const lender1Basics = updatedReturnContext[1].returnValues;
 
   const interestRate0 = toBig(lender0Basics[1]);
-  const borrowAPR0 = interestRate0.eq('0') ? 0 : interestRate0.sub(1e12).div(1e12).toNumber() * secondsInYear;
+  const borrowerAPR0 = interestRate0.eq('0') ? 0 : interestRate0.sub(1e12).div(1e12).toNumber() * secondsInYear;
   const interestRate1 = toBig(lender1Basics[1]);
-  const borrowAPR1 = interestRate1.eq('0') ? 0 : interestRate1.sub(1e12).div(1e12).toNumber() * secondsInYear;
+  const borrowerAPR1 = interestRate1.eq('0') ? 0 : interestRate1.sub(1e12).div(1e12).toNumber() * secondsInYear;
   const lender0Utilization = toImpreciseNumber(lender0Basics[2], 18);
   const lender1Utilization = toImpreciseNumber(lender1Basics[2], 18);
   const lender0TotalSupply = toBig(lender0Basics[3]);
@@ -288,13 +288,13 @@ export async function fetchMarketInfoFor(
   return {
     lender0,
     lender1,
-    borrowerAPR0: borrowAPR0,
-    borrowerAPR1: borrowAPR1,
-    lender0Utilization: lender0Utilization,
-    lender1Utilization: lender1Utilization,
-    lender0TotalSupply: lender0TotalSupply,
-    lender1TotalSupply: lender1TotalSupply,
-    lender0TotalBorrows: lender0TotalBorrows,
-    lender1TotalBorrows: lender1TotalBorrows,
+    borrowerAPR0,
+    borrowerAPR1,
+    lender0Utilization,
+    lender1Utilization,
+    lender0TotalSupply,
+    lender1TotalSupply,
+    lender0TotalBorrows,
+    lender1TotalBorrows,
   };
 }

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -11,7 +11,7 @@ import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
 import { makeEtherscanRequest } from '../util/Etherscan';
 import { ContractCallReturnContextEntries, convertBigNumbersForReturnContexts } from '../util/Multicall';
-import { toBig } from '../util/Numbers';
+import { toBig, toImpreciseNumber } from '../util/Numbers';
 import {
   ALOE_II_BORROWER_LENS_ADDRESS,
   ALOE_II_FACTORY_ADDRESS,
@@ -208,31 +208,19 @@ export async function fetchMarginAccounts(
     const assetsData = lensReturnContexts[0].returnValues;
     const liabilitiesData = lensReturnContexts[1].returnValues;
     const healthData = lensReturnContexts[2].returnValues;
-    const healthData0 = Big(healthData[0].toString());
-    const healthData1 = Big(healthData[1].toString());
-    const health = healthData0.lt(healthData1) ? healthData0 : healthData1;
+
+    const health = toImpreciseNumber(healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1], 18);
     const assets: Assets = {
-      token0Raw: Big(assetsData[0].toString())
-        .div(10 ** token0.decimals)
-        .toNumber(),
-      token1Raw: Big(assetsData[1].toString())
-        .div(10 ** token1.decimals)
-        .toNumber(),
-      uni0: Big(assetsData[4].toString())
-        .div(10 ** token0.decimals)
-        .toNumber(),
-      uni1: Big(assetsData[5].toString())
-        .div(10 ** token1.decimals)
-        .toNumber(),
+      token0Raw: toImpreciseNumber(assetsData[0], token0.decimals),
+      token1Raw: toImpreciseNumber(assetsData[1], token1.decimals),
+      uni0: toImpreciseNumber(assetsData[4], token0.decimals),
+      uni1: toImpreciseNumber(assetsData[5], token1.decimals),
     };
     const liabilities: Liabilities = {
-      amount0: Big(liabilitiesData[0].toString())
-        .div(10 ** token0.decimals)
-        .toNumber(),
-      amount1: Big(liabilitiesData[1].toString())
-        .div(10 ** token1.decimals)
-        .toNumber(),
+      amount0: toImpreciseNumber(liabilitiesData[0], token0.decimals),
+      amount1: toImpreciseNumber(liabilitiesData[1], token1.decimals),
     };
+
     const lender0 = accountResults.callsReturnContext[0].returnValues[0];
     const lender1 = accountResults.callsReturnContext[1].returnValues[0];
     const oracleReturnValues = convertBigNumbersForReturnContexts(oracleResults.callsReturnContext)[0].returnValues;
@@ -242,13 +230,13 @@ export async function fetchMarginAccounts(
       feeTier: feeTier,
       assets: assets,
       liabilities: liabilities,
-      health: health.toNumber(),
+      health: health,
       token0: token0,
       token1: token1,
       lender0: lender0,
       lender1: lender1,
       sqrtPriceX96: toBig(oracleReturnValues[0]),
-      iv: oracleReturnValues[1].div(1e9).toNumber() / 1e9,
+      iv: toImpreciseNumber(oracleReturnValues[1], 18),
     };
     marginAccounts.push(marginAccount);
   });
@@ -287,16 +275,16 @@ export async function fetchMarketInfoFor(
   const lender0Basics = updatedReturnContext[0].returnValues;
   const lender1Basics = updatedReturnContext[1].returnValues;
 
-  const interestRate0 = new Big(lender0Basics[1].toString());
+  const interestRate0 = toBig(lender0Basics[1]);
   const borrowAPR0 = interestRate0.eq('0') ? 0 : interestRate0.sub(1e12).div(1e12).toNumber() * secondsInYear;
-  const interestRate1 = new Big(lender1Basics[1].toString());
+  const interestRate1 = toBig(lender1Basics[1]);
   const borrowAPR1 = interestRate1.eq('0') ? 0 : interestRate1.sub(1e12).div(1e12).toNumber() * secondsInYear;
-  const lender0Utilization = new Big(lender0Basics[2].toString()).div(10 ** 18).toNumber();
-  const lender1Utilization = new Big(lender1Basics[2].toString()).div(10 ** 18).toNumber();
-  const lender0TotalSupply = new Big(lender0Basics[3].toString());
-  const lender1TotalSupply = new Big(lender1Basics[3].toString());
-  const lender0TotalBorrows = new Big(lender0Basics[4].toString());
-  const lender1TotalBorrows = new Big(lender1Basics[4].toString());
+  const lender0Utilization = toImpreciseNumber(lender0Basics[2], 18);
+  const lender1Utilization = toImpreciseNumber(lender1Basics[2], 18);
+  const lender0TotalSupply = toBig(lender0Basics[3]);
+  const lender1TotalSupply = toBig(lender1Basics[3]);
+  const lender0TotalBorrows = toBig(lender0Basics[4]);
+  const lender1TotalBorrows = toBig(lender1Basics[4]);
   return {
     lender0,
     lender1,

--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -14,6 +14,18 @@ export function toBig(value: ethers.BigNumber | ethers.utils.Result): Big {
   return new Big(value.toString());
 }
 
+/**
+ * Converts a BigNumber (ethers type) to a standard Javascript number, but may lose precision in the decimal
+ * places (because floats be like that)
+ * @param value Source value in fixed point
+ * @param decimals Number of decimals in the source
+ * @returns Javascript number, approximately equal to `value`
+ */
+export function toImpreciseNumber(value: ethers.BigNumber | ethers.utils.Result, decimals: number): number {
+  const big = toBig(value);
+  return big.div(10 ** decimals).toNumber();
+}
+
 export function String1E(decimals: number): string {
   return `1${'0'.repeat(decimals)}`;
 }

--- a/prime/src/data/MarginAccount.ts
+++ b/prime/src/data/MarginAccount.ts
@@ -6,7 +6,7 @@ import { Address, Chain } from 'wagmi';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
 import { makeEtherscanRequest } from '../util/Etherscan';
-import { toBig } from '../util/Numbers';
+import { toBig, toImpreciseNumber } from '../util/Numbers';
 import { ALOE_II_FACTORY_ADDRESS, ALOE_II_ORACLE } from './constants/Addresses';
 import { TOPIC0_CREATE_BORROWER_EVENT } from './constants/Signatures';
 import { Token } from './Token';
@@ -116,28 +116,16 @@ export async function fetchMarginAccountPreviews(
         return null;
       }
 
-      const health = healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1];
+      const health = toImpreciseNumber(healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1], 18);
       const assets: Assets = {
-        token0Raw: Big(assetsData.fixed0.toString())
-          .div(10 ** token0.decimals)
-          .toNumber(),
-        token1Raw: Big(assetsData.fixed1.toString())
-          .div(10 ** token1.decimals)
-          .toNumber(),
-        uni0: Big(assetsData.fluid0C.toString())
-          .div(10 ** token0.decimals)
-          .toNumber(),
-        uni1: Big(assetsData.fluid1C.toString())
-          .div(10 ** token1.decimals)
-          .toNumber(),
+        token0Raw: toImpreciseNumber(assetsData.fixed0, token0.decimals),
+        token1Raw: toImpreciseNumber(assetsData.fixed1, token1.decimals),
+        uni0: toImpreciseNumber(assetsData.fluid0C, token0.decimals),
+        uni1: toImpreciseNumber(assetsData.fluid1C, token1.decimals),
       };
       const liabilities: Liabilities = {
-        amount0: Big(liabilitiesData.amount0.toString())
-          .div(10 ** token0.decimals)
-          .toNumber(),
-        amount1: Big(liabilitiesData.amount1.toString())
-          .div(10 ** token1.decimals)
-          .toNumber(),
+        amount0: toImpreciseNumber(liabilitiesData.amount0, token0.decimals),
+        amount1: toImpreciseNumber(liabilitiesData.amount1, token1.decimals),
       };
       return {
         address: accountAddress,
@@ -147,7 +135,7 @@ export async function fetchMarginAccountPreviews(
         feeTier,
         assets,
         liabilities,
-        health: health.div(1e9).toNumber() / 1e9,
+        health: health,
       };
     }
   );
@@ -191,30 +179,18 @@ export async function fetchMarginAccount(
   ]);
 
   const assets: Assets = {
-    token0Raw: Big(assetsData.fixed0.toString())
-      .div(10 ** token0.decimals)
-      .toNumber(),
-    token1Raw: Big(assetsData.fixed1.toString())
-      .div(10 ** token1.decimals)
-      .toNumber(),
-    uni0: Big(assetsData.fluid0C.toString())
-      .div(10 ** token0.decimals)
-      .toNumber(),
-    uni1: Big(assetsData.fluid1C.toString())
-      .div(10 ** token1.decimals)
-      .toNumber(),
+    token0Raw: toImpreciseNumber(assetsData.fixed0, token0.decimals),
+    token1Raw: toImpreciseNumber(assetsData.fixed1, token1.decimals),
+    uni0: toImpreciseNumber(assetsData.fluid0C, token0.decimals),
+    uni1: toImpreciseNumber(assetsData.fluid1C, token1.decimals),
   };
   const liabilities: Liabilities = {
-    amount0: Big(liabilitiesData.amount0.toString())
-      .div(10 ** token0.decimals)
-      .toNumber(),
-    amount1: Big(liabilitiesData.amount1.toString())
-      .div(10 ** token1.decimals)
-      .toNumber(),
+    amount0: toImpreciseNumber(liabilitiesData.amount0, token0.decimals),
+    amount1: toImpreciseNumber(liabilitiesData.amount1, token1.decimals),
   };
 
   const healthData = results[7];
-  const health = healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1];
+  const health = toImpreciseNumber(healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1], 18);
 
   return {
     marginAccount: {
@@ -226,10 +202,10 @@ export async function fetchMarginAccount(
       assets: assets,
       liabilities: liabilities,
       sqrtPriceX96: toBig(oracleResult[0]),
-      health: health.div(1e9).toNumber() / 1e9,
+      health: health,
       lender0: lender0,
       lender1: lender1,
-      iv: oracleResult[1].div(1e9).toNumber() / 1e9,
+      iv: toImpreciseNumber(oracleResult[1], 18),
     },
   };
 }

--- a/prime/src/data/MarginAccount.ts
+++ b/prime/src/data/MarginAccount.ts
@@ -191,21 +191,22 @@ export async function fetchMarginAccount(
 
   const healthData = results[7];
   const health = toImpreciseNumber(healthData[0].lt(healthData[1]) ? healthData[0] : healthData[1], 18);
+  const iv = toImpreciseNumber(oracleResult[1], 18);
 
   return {
     marginAccount: {
       address: marginAccountAddress,
-      uniswapPool: uniswapPool,
-      token0: token0,
-      token1: token1,
       feeTier: NumericFeeTierToEnum(feeTier),
-      assets: assets,
-      liabilities: liabilities,
       sqrtPriceX96: toBig(oracleResult[0]),
-      health: health,
-      lender0: lender0,
-      lender1: lender1,
-      iv: toImpreciseNumber(oracleResult[1], 18),
+      uniswapPool,
+      token0,
+      token1,
+      assets,
+      liabilities,
+      health,
+      lender0,
+      lender1,
+      iv,
     },
   };
 }

--- a/prime/src/data/MarketInfo.ts
+++ b/prime/src/data/MarketInfo.ts
@@ -3,6 +3,8 @@ import { secondsInYear } from 'date-fns';
 import { ethers } from 'ethers';
 import { Address } from 'wagmi';
 
+import { toBig, toImpreciseNumber } from '../util/Numbers';
+
 export type MarketInfo = {
   lender0: Address;
   lender1: Address;
@@ -26,16 +28,16 @@ export async function fetchMarketInfoFor(
     lenderLensContract.readBasics(lender1),
   ]);
 
-  const interestRate0 = new Big(lender0Basics.interestRate.toString());
+  const interestRate0 = toBig(lender0Basics.interestRate);
   const borrowAPR0 = interestRate0.eq('0') ? 0 : interestRate0.sub(1e12).div(1e12).toNumber() * secondsInYear;
-  const interestRate1 = new Big(lender1Basics.interestRate.toString());
+  const interestRate1 = toBig(lender1Basics.interestRate);
   const borrowAPR1 = interestRate1.eq('0') ? 0 : interestRate1.sub(1e12).div(1e12).toNumber() * secondsInYear;
-  const lender0Utilization = new Big(lender0Basics.utilization.toString()).div(10 ** 18).toNumber();
-  const lender1Utilization = new Big(lender1Basics.utilization.toString()).div(10 ** 18).toNumber();
-  const lender0Inventory = new Big(lender0Basics.inventory.toString());
-  const lender1Inventory = new Big(lender1Basics.inventory.toString());
-  const lender0TotalBorrows = new Big(lender0Basics.totalBorrows.toString());
-  const lender1TotalBorrows = new Big(lender1Basics.totalBorrows.toString());
+  const lender0Utilization = toImpreciseNumber(lender0Basics.utilization, 18);
+  const lender1Utilization = toImpreciseNumber(lender1Basics.utilization, 18);
+  const lender0Inventory = toBig(lender0Basics.inventory);
+  const lender1Inventory = toBig(lender1Basics.inventory);
+  const lender0TotalBorrows = toBig(lender0Basics.totalBorrows);
+  const lender1TotalBorrows = toBig(lender1Basics.totalBorrows);
   return {
     lender0,
     lender1,

--- a/prime/src/util/Numbers.ts
+++ b/prime/src/util/Numbers.ts
@@ -14,6 +14,18 @@ export function toBig(value: ethers.BigNumber | ethers.utils.Result): Big {
   return new Big(value.toString());
 }
 
+/**
+ * Converts a BigNumber (ethers type) to a standard Javascript number, but may lose precision in the decimal
+ * places (because floats be like that)
+ * @param value Source value in fixed point
+ * @param decimals Number of decimals in the source
+ * @returns Javascript number, approximately equal to `value`
+ */
+export function toImpreciseNumber(value: ethers.BigNumber | ethers.utils.Result, decimals: number): number {
+  const big = toBig(value);
+  return big.div(10 ** decimals).toNumber();
+}
+
 export function String1E(decimals: number): string {
   return `1${'0'.repeat(decimals)}`;
 }


### PR DESCRIPTION
Sometimes the health computed by the borrower lens was larger than Javascript could handle, resulting in Prime page crashing.

Also, the health on the earn Borrow page was not being divided by 1e18.

I added a new util function to make things clearer. Both issues are fixed now.