### PR TITLE
Adding mobile version of the navbar

### DIFF
--- a/shared/src/assets/svg/Menu.tsx
+++ b/shared/src/assets/svg/Menu.tsx
@@ -1,0 +1,11 @@
+import { SVGProps } from '.';
+
+export default function Menu(props: SVGProps) {
+  return (
+    <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' {...props}>
+      <path d='M3 18H21' stroke='#070E12' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+      <path d='M3 12H21' stroke='#070E12' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+      <path d='M3 6H21' stroke='#070E12' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+    </svg>
+  );
+}

--- a/shared/src/components/common/Footer.tsx
+++ b/shared/src/components/common/Footer.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import DiscordFooterIcon from '../../assets/svg/DiscordFooter';
 import TwitterFooterIcon from '../../assets/svg/TwitterFooter';
 import MediumFooterIcon from '../../assets/svg/MediumFooter';
-import { RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
+import { RESPONSIVE_BREAKPOINT_MD } from '../../data/constants/Breakpoints';
 
 const FOOTER_LINK_TEXT_COLOR = 'rgba(75, 105, 128, 1)';
 
@@ -26,7 +26,7 @@ const StyledFooter = styled.footer`
   padding-right: 180px;
   z-index: 40;
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     display: none;
   }
 `;

--- a/shared/src/components/navbar/AccountInfo.tsx
+++ b/shared/src/components/navbar/AccountInfo.tsx
@@ -4,7 +4,7 @@ import { Popover } from '@headlessui/react';
 import { GetAccountResult, Provider } from '@wagmi/core';
 import { FilledGreyButton, FilledGreyButtonWithIcon, FilledStylizedButton } from '../common/Buttons';
 import { Text } from '../common/Typography';
-import { RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
+import { RESPONSIVE_BREAKPOINT_MD, RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
 import styled from 'styled-components';
 import { Chain, useConnect, useEnsName, chain as wagmiChain } from 'wagmi';
 
@@ -50,7 +50,7 @@ const ButtonTextContainer = styled.div`
   flex-direction: row;
   align-items: center;
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     display: none;
   }
 `;

--- a/shared/src/components/navbar/NavBar.tsx
+++ b/shared/src/components/navbar/NavBar.tsx
@@ -5,8 +5,9 @@ import { NavLink } from 'react-router-dom';
 import DiscordFooterIcon from '../../assets/svg/DiscordFooter';
 import MediumFooterIcon from '../../assets/svg/MediumFooter';
 import TwitterFooterIcon from '../../assets/svg/TwitterFooter';
+import CloseModal from '../../assets/svg/CloseModal';
+import MenuIcon from '../../assets/svg/Menu';
 import { Text } from '../common/Typography';
-import { RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
 import styled from 'styled-components';
 import { Chain, useAccount, useNetwork, useDisconnect } from 'wagmi';
 
@@ -16,6 +17,13 @@ import EllipsisIcon from '../../assets/svg/Ellipsis';
 import AccountInfo from './AccountInfo';
 import ChainSelector from './ChainSelector';
 import ConnectWalletButton from './ConnectWalletButton';
+import {
+  RESPONSIVE_BREAKPOINTS,
+  RESPONSIVE_BREAKPOINT_MD,
+  RESPONSIVE_BREAKPOINT_XS,
+} from '../../data/constants/Breakpoints';
+import useMediaQuery from '../../data/hooks/UseMediaQuery';
+import useLockScroll from '../../data/hooks/UseLockScroll';
 
 const FOOTER_LINK_TEXT_COLOR = 'rgba(75, 105, 128, 1)';
 
@@ -23,7 +31,7 @@ const DesktopLogo = styled(AloeDesktopLogo)`
   width: 100px;
   height: 40px;
   margin-right: 32px;
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     display: none;
   }
 `;
@@ -32,7 +40,7 @@ const MobileLogo = styled(AloeMobileLogo)`
   width: 40px;
   height: 40px;
   margin-right: 32px;
-  @media (min-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (min-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     display: none;
   }
 `;
@@ -48,6 +56,27 @@ const DesktopTopNav = styled.div`
   padding: 0 32px;
 `;
 
+const TabletBottomNav = styled.div`
+  position: fixed;
+  display: flex;
+  justify-content: space-between;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background-color: rgba(6, 11, 15, 1);
+  border-top: 1px solid rgba(26, 41, 52, 1);
+  padding: 8px 16px;
+
+  @media (min-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    display: none;
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_XS}) {
+    display: none;
+  }
+`;
+
 const MobileBottomNav = styled.div`
   position: fixed;
   display: flex;
@@ -60,7 +89,7 @@ const MobileBottomNav = styled.div`
   border-top: 1px solid rgba(26, 41, 52, 1);
   padding: 8px 16px;
 
-  @media (min-width: 768px) {
+  @media (min-width: ${RESPONSIVE_BREAKPOINT_XS}) {
     display: none;
   }
 `;
@@ -70,7 +99,7 @@ const VerticalDivider = styled.div`
   height: 64px;
   background-color: rgba(26, 41, 52, 1);
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     width: 100%;
     height: 1px;
   }
@@ -83,10 +112,29 @@ const FooterLink = styled(Text)`
   }
 `;
 
+const ExternalFooterLinkWithIcon = styled.a`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+
+  padding: 8px 16px;
+  color: ${FOOTER_LINK_TEXT_COLOR};
+  &:hover {
+    color: rgba(255, 255, 255, 1);
+
+    svg {
+      path {
+        fill: rgba(255, 255, 255, 1);
+      }
+    }
+  }
+`;
+
 const DesktopNavLinks = styled.div`
   display: flex;
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     display: none;
   }
 `;
@@ -109,7 +157,7 @@ const DesktopNavLink = styled(NavLink)`
     border-bottom: 1px solid rgba(26, 41, 52, 1);
   }
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     width: 100%;
     padding: 12px 0px;
   }
@@ -133,7 +181,7 @@ const ExternalDesktopLink = styled.a`
     border-bottom: 1px solid rgba(26, 41, 52, 1);
   }
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     width: 100%;
     padding: 12px 0px;
   }
@@ -184,6 +232,36 @@ const StyledPopoverPanel = styled(Popover.Panel)`
   padding: 16px;
 `;
 
+const NavOverlay = styled.div`
+  position: fixed;
+  top: 64px;
+  bottom: 64px;
+  left: 0;
+  right: 0;
+  background-color: rgb(13, 23, 30);
+  z-index: 40;
+  padding: 16px;
+  overflow-y: scroll;
+
+  @media (min-width: ${RESPONSIVE_BREAKPOINT_XS}) {
+    display: none;
+  }
+`;
+
+const MenuIconWrapper = styled.button`
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  cursor: pointer;
+  user-select: none;
+
+  svg {
+    path {
+      stroke: #ffffff;
+    }
+  }
+`;
+
 export type NavBarLink = {
   label: string;
   to: string;
@@ -200,16 +278,27 @@ export type NavBarProps = {
 
 export function NavBar(props: NavBarProps) {
   const { links, isAllowedToInteract, activeChain, checkboxes, setActiveChain } = props;
+  const [isNavDrawerOpen, setIsNavDrawerOpen] = useState(false);
   const account = useAccount();
   const network = useNetwork();
   const { disconnect } = useDisconnect();
   const [isSelectChainDropdownOpen, setIsSelectChainDropdownOpen] = useState(false);
+  const { lockScroll, unlockScroll } = useLockScroll();
   useEffect(() => {
     // Close the chain selector dropdown when the chain changes
     setIsSelectChainDropdownOpen(false);
   }, [network.chain]);
 
   const isOffline = !account.isConnected && !account.isConnecting;
+
+  const isBiggerThanMobile = useMediaQuery(RESPONSIVE_BREAKPOINTS.XS);
+
+  useEffect(() => {
+    if (isNavDrawerOpen && isBiggerThanMobile) {
+      setIsNavDrawerOpen(false);
+      unlockScroll();
+    }
+  }, [isBiggerThanMobile, isNavDrawerOpen, unlockScroll]);
 
   return (
     <>
@@ -260,7 +349,7 @@ export function NavBar(props: NavBarProps) {
           )}
         </div>
       </DesktopTopNav>
-      <MobileBottomNav>
+      <TabletBottomNav>
         {props.links.map((link, index) => (
           <React.Fragment key={index}>
             {link.isExternal ? (
@@ -346,7 +435,126 @@ export function NavBar(props: NavBarProps) {
             </div>
           </StyledPopoverPanel>
         </Popover>
+      </TabletBottomNav>
+      <MobileBottomNav>
+        <MenuIconWrapper
+          onClick={() => {
+            if (isNavDrawerOpen) {
+              setIsNavDrawerOpen(false);
+              unlockScroll();
+            } else {
+              lockScroll();
+              setIsNavDrawerOpen(true);
+            }
+          }}
+        >
+          {isNavDrawerOpen ? <CloseModal width={28} height={28} /> : <MenuIcon width={28} height={28} />}
+        </MenuIconWrapper>
       </MobileBottomNav>
+      {isNavDrawerOpen && (
+        <NavOverlay>
+          <div className='flex flex-col justify-between h-full'>
+            <div className='flex flex-col gap-4'>
+              {props.links.map((link, index) => (
+                <React.Fragment key={index}>
+                  {link.isExternal ? (
+                    <MobileExternalLink href={link.to} target='_blank' rel='noopener noreferrer'>
+                      <Text size='XL' weight='bold'>
+                        {link.label}
+                      </Text>
+                    </MobileExternalLink>
+                  ) : (
+                    <MobileNavLink
+                      to={link.to}
+                      onClick={() => {
+                        setIsNavDrawerOpen(false);
+                        unlockScroll();
+                      }}
+                    >
+                      <Text size='XL' weight='bold'>
+                        {link.label}
+                      </Text>
+                    </MobileNavLink>
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+            <div className='mt-4'>
+              <div className='flex flex-col gap-2'>
+                <FooterLink
+                  as='a'
+                  size='M'
+                  weight='medium'
+                  color={FOOTER_LINK_TEXT_COLOR}
+                  href={'https://aloe.capital/'}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  Main site
+                </FooterLink>
+                <FooterLink
+                  as='a'
+                  size='M'
+                  weight='medium'
+                  color={FOOTER_LINK_TEXT_COLOR}
+                  href={'https://docs.aloe.capital/'}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  Docs
+                </FooterLink>
+                <FooterLink
+                  as='a'
+                  size='M'
+                  weight='medium'
+                  color={FOOTER_LINK_TEXT_COLOR}
+                  href={'/terms.pdf'}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  Terms
+                </FooterLink>
+              </div>
+              <div className='flex flex-col gap-2 mt-2'>
+                <ExternalFooterLinkWithIcon
+                  href={'https://discord.com/invite/gpt4sUv6sw'}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  title='Join our Discord'
+                  className=''
+                >
+                  <DiscordFooterIcon width={14} height={11} />
+                  <Text size='M' weight='medium' color='unset'>
+                    Discord
+                  </Text>
+                </ExternalFooterLinkWithIcon>
+                <ExternalFooterLinkWithIcon
+                  href={'https://twitter.com/aloecapital'}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  title='Follow us on Twitter'
+                >
+                  <TwitterFooterIcon width={15} height={11} />
+                  <Text size='M' weight='medium' color='unset'>
+                    Twitter
+                  </Text>
+                </ExternalFooterLinkWithIcon>
+                <ExternalFooterLinkWithIcon
+                  href={'https://aloelabs.medium.com'}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  title='Connect with us on Medium'
+                >
+                  <MediumFooterIcon width={21} height={11} />
+                  <Text size='M' weight='medium' color='unset'>
+                    Medium
+                  </Text>
+                </ExternalFooterLinkWithIcon>
+              </div>
+            </div>
+          </div>
+        </NavOverlay>
+      )}
     </>
   );
 }

--- a/shared/src/data/hooks/UseLockScroll.ts
+++ b/shared/src/data/hooks/UseLockScroll.ts
@@ -1,0 +1,9 @@
+export default function useLockScroll(): { lockScroll: () => void; unlockScroll: () => void } {
+  const lockScroll = () => {
+    document.body.style.overflow = 'hidden';
+  };
+  const unlockScroll = () => {
+    document.body.style.overflow = 'auto';
+  };
+  return { lockScroll, unlockScroll };
+}


### PR DESCRIPTION
Adding a more responsive system for phones, tablets, laptops, and desktops. While this PR adds a bit of complexity to the navbar component, it also enables a better UX as it ensures we provide a navigation interface that works well with just about any device a user may have. On a very narrow screen, such as a phone, the navbar collapses into a menu button. The user can click a menu button at the bottom left of the screen, which is a good placement for users on mobile devices, which, when clicked, opens a full-screen nav drawer that allows users to see and click links that are better suited for use with fingers. When it comes to tablets, we now use what was previously meant to be used with phones, which is the interface with the navbar links moved to the bottom for easier access and so that we can declutter the top nav bar. Besides a few other tweaks, the desktop navbar is unchanged.
**Vertical Phone (nav drawer closed)**
<img width="324" alt="Screenshot 2023-02-26 at 1 40 13 PM" src="https://user-images.githubusercontent.com/17186604/221430042-78df9871-de9a-47b5-8689-cc693145d37d.png">
**Vertical Phone (nav drawer open)**
<img width="324" alt="Screenshot 2023-02-26 at 1 40 19 PM" src="https://user-images.githubusercontent.com/17186604/221430041-06faa3c9-b013-4e86-9fb6-583af68c155b.png">
**Horizontal Phone**
<img width="769" alt="Screenshot 2023-02-26 at 1 40 37 PM" src="https://user-images.githubusercontent.com/17186604/221430038-0bfc2062-3490-44e6-83d6-9bbddaa44c24.png">


