### PR TITLE
Centering balance and apy

### DIFF
--- a/earn/src/components/portfolio/PortfolioGrid.tsx
+++ b/earn/src/components/portfolio/PortfolioGrid.tsx
@@ -58,6 +58,7 @@ export const PieChartContainer = styled(BaseGridItem)`
 export const BalanceContainer = styled(BaseGridItem)`
   grid-area: balance;
   position: relative;
+  text-align: center;
   @media (min-width: ${RESPONSIVE_BREAKPOINT_SM}) {
     &.active::before {
       content: '';
@@ -75,6 +76,7 @@ export const BalanceContainer = styled(BaseGridItem)`
 export const APYContainer = styled(BaseGridItem)`
   grid-area: apy;
   position: relative;
+  text-align: center;
   @media (min-width: ${RESPONSIVE_BREAKPOINT_SM}) {
     &.active::before {
       content: '';


### PR DESCRIPTION
As the title suggests, I am centering the balance and APY to look better even when the value causes the card to overflow.
Before:
<img width="938" alt="Screenshot 2023-03-11 at 5 55 19 PM" src="https://user-images.githubusercontent.com/17186604/224515143-708a9cf1-333d-4697-bf4a-ea2a51653394.png">
After:
<img width="938" alt="Screenshot 2023-03-11 at 5 55 25 PM" src="https://user-images.githubusercontent.com/17186604/224515148-bff62a9e-09dc-4659-ba6e-34c6fbc6d19e.png">
