### PR TITLE
Fixing etherscan on optimism

### DIFF
--- a/earn/src/util/Etherscan.ts
+++ b/earn/src/util/Etherscan.ts
@@ -11,7 +11,7 @@ const ETHERSCAN_DOMAINS_BY_CHAIN_ID = {
 const ETHERSCAN_API_KEYS = {
   [wagmiChain.mainnet.id]: process.env.REACT_APP_ETHERSCAN_API_KEY,
   [wagmiChain.goerli.id]: process.env.REACT_APP_ETHERSCAN_API_KEY,
-  [wagmiChain.optimism.id]: process.env.REACT_APP_ETHERSCAN_API_KEY,
+  [wagmiChain.optimism.id]: process.env.REACT_APP_OPTIMISTIC_ETHERSCAN_API_KEY,
   [wagmiChain.arbitrum.id]: process.env.REACT_APP_ARBISCAN_API_KEY,
 };
 

--- a/prime/src/util/Etherscan.ts
+++ b/prime/src/util/Etherscan.ts
@@ -11,7 +11,7 @@ const ETHERSCAN_DOMAINS_BY_CHAIN_ID = {
 const ETHERSCAN_API_KEYS = {
   [wagmiChain.mainnet.id]: process.env.REACT_APP_ETHERSCAN_API_KEY,
   [wagmiChain.goerli.id]: process.env.REACT_APP_ETHERSCAN_API_KEY,
-  [wagmiChain.optimism.id]: process.env.REACT_APP_ETHERSCAN_API_KEY,
+  [wagmiChain.optimism.id]: process.env.REACT_APP_OPTIMISTIC_ETHERSCAN_API_KEY,
   [wagmiChain.arbitrum.id]: process.env.REACT_APP_ARBISCAN_API_KEY,
 };
 


### PR DESCRIPTION
As the title suggests, Etherscan just made it so that we need separate API keys for optimism and mainnet leading us to update our code accordingly. Netlify should already have the new API keys in the env variables. Once merged, we just need to switch the normal Etherscan API key back (since I switched it to mitigate the issue initially).