### PR TITLE
Adding a healthbar to borrow modal

### DIFF
--- a/earn/src/components/borrow/HealthBar.tsx
+++ b/earn/src/components/borrow/HealthBar.tsx
@@ -48,7 +48,7 @@ export default function HealthBar(props: HealthBarProps) {
     ((Math.max(Math.min(health, MAX_HEALTH), MIN_HEALTH) - MIN_HEALTH) / (MAX_HEALTH - MIN_HEALTH)) * 100;
   const healthLabel = health > MAX_HEALTH ? `${MAX_HEALTH}+` : health.toFixed(2);
   return (
-    <div className='w-full flex flex-col align-middle mb-8 mt-8'>
+    <div className='w-full flex flex-col align-middle'>
       <div className='flex gap-2 items-center mb-4'>
         <Tooltip
           buttonSize='S'

--- a/earn/src/components/borrow/HealthBar.tsx
+++ b/earn/src/components/borrow/HealthBar.tsx
@@ -8,7 +8,7 @@ const MIN_HEALTH = 0.5;
 
 const HealthBarContainer = styled.div`
   width: 100%;
-  height: 32px;
+  height: 16px;
   background: rgb(235, 87, 87);
   background: linear-gradient(
     90deg,
@@ -18,7 +18,7 @@ const HealthBarContainer = styled.div`
     rgba(0, 193, 67, 1) 70%,
     rgba(0, 193, 67, 1) 100%
   );
-  border-radius: 8px;
+  border-radius: 4px;
   position: relative;
 `;
 
@@ -26,12 +26,12 @@ const HealthBarDial = styled.div.attrs((props: { healthPercent: number }) => pro
   width: 0;
   height: 0;
   border-style: solid;
-  border-width: 10px 10px 0 10px;
+  border-width: 5px 5px 0 5px;
   border-color: #ffffff transparent transparent transparent;
   position: absolute;
   left: ${(props) => props.healthPercent}%;
   transform: translateX(-50%);
-  top: -4.325px;
+  top: -2.325px;
 `;
 
 export type HealthBarProps = {
@@ -57,10 +57,10 @@ export default function HealthBar(props: HealthBarProps) {
               If your health is at or below 1.0, your account may be liquidated.`}
           position='top-left'
         />
-        <Text size='M' weight='medium'>
+        <Text size='S' weight='medium'>
           Account Health:
         </Text>
-        <Display size='S' weight='medium' className='text-center'>
+        <Display size='XS' weight='medium' className='text-center'>
           {healthLabel}
         </Display>
       </div>

--- a/earn/src/components/borrow/HealthBar.tsx
+++ b/earn/src/components/borrow/HealthBar.tsx
@@ -1,0 +1,72 @@
+import { Display, Text } from 'shared/lib/components/common/Typography';
+import styled from 'styled-components';
+
+import Tooltip from '../common/Tooltip';
+
+const MAX_HEALTH = 3;
+const MIN_HEALTH = 0.5;
+
+const HealthBarContainer = styled.div`
+  width: 100%;
+  height: 32px;
+  background: rgb(235, 87, 87);
+  background: linear-gradient(
+    90deg,
+    rgba(235, 87, 87, 1) 0%,
+    rgba(235, 87, 87, 1) 20%,
+    rgba(242, 201, 76, 1) 23%,
+    rgba(0, 193, 67, 1) 70%,
+    rgba(0, 193, 67, 1) 100%
+  );
+  border-radius: 8px;
+  position: relative;
+`;
+
+const HealthBarDial = styled.div.attrs((props: { healthPercent: number }) => props)`
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 10px 10px 0 10px;
+  border-color: #ffffff transparent transparent transparent;
+  position: absolute;
+  left: ${(props) => props.healthPercent}%;
+  transform: translateX(-50%);
+  top: -4.325px;
+`;
+
+export type HealthBarProps = {
+  health: number;
+};
+
+// NOTE: This component's text is smaller than the version on prime.
+// This is because of where it is used in the UI. If this needs to be
+// used in other places, with different needs, we should make it more flexible.
+export default function HealthBar(props: HealthBarProps) {
+  const { health } = props;
+  // Bound health between MIN_HEALTH and MAX_HEALTH
+  const healthPercent =
+    ((Math.max(Math.min(health, MAX_HEALTH), MIN_HEALTH) - MIN_HEALTH) / (MAX_HEALTH - MIN_HEALTH)) * 100;
+  const healthLabel = health > MAX_HEALTH ? `${MAX_HEALTH}+` : health.toFixed(2);
+  return (
+    <div className='w-full flex flex-col align-middle mb-8 mt-8'>
+      <div className='flex gap-2 items-center mb-4'>
+        <Tooltip
+          buttonSize='S'
+          content={`Health is a measure of how close your account is to being liquidated.
+              It is calculated by dividing your account's assets by its liabilities.
+              If your health is at or below 1.0, your account may be liquidated.`}
+          position='top-left'
+        />
+        <Text size='M' weight='medium'>
+          Account Health:
+        </Text>
+        <Display size='S' weight='medium' className='text-center'>
+          {healthLabel}
+        </Display>
+      </div>
+      <HealthBarContainer>
+        <HealthBarDial healthPercent={healthPercent} />
+      </HealthBarContainer>
+    </div>
+  );
+}

--- a/earn/src/components/borrow/modal/BorrowModal.tsx
+++ b/earn/src/components/borrow/modal/BorrowModal.tsx
@@ -309,8 +309,8 @@ export default function BorrowModal(props: BorrowModalProps) {
               liquidated.
             </Text>
           )}
-          <HealthBar health={newHealth} />
         </div>
+        <HealthBar health={newHealth} />
         <div className='w-full'>
           <BorrowButton
             marginAccount={marginAccount}

--- a/earn/src/components/borrow/modal/BorrowModal.tsx
+++ b/earn/src/components/borrow/modal/BorrowModal.tsx
@@ -309,8 +309,10 @@ export default function BorrowModal(props: BorrowModalProps) {
               liquidated.
             </Text>
           )}
+          <div className='mt-2'>
+            <HealthBar health={newHealth} />
+          </div>
         </div>
-        <HealthBar health={newHealth} />
         <div className='w-full'>
           <BorrowButton
             marginAccount={marginAccount}

--- a/earn/src/components/borrow/modal/BorrowModal.tsx
+++ b/earn/src/components/borrow/modal/BorrowModal.tsx
@@ -43,7 +43,7 @@ function getConfirmButton(state: ConfirmButtonState, token: Token): { text: stri
     case ConfirmButtonState.UNHEALTHY:
       return { text: 'Insufficient Collateral', enabled: false };
     case ConfirmButtonState.NOT_ENOUGH_SUPPLY:
-      return { text: `Not enough ${token.ticker} supply`, enabled: false };
+      return { text: `Not Enough ${token.ticker} Supply`, enabled: false };
     case ConfirmButtonState.LOADING:
       return { text: 'Loading...', enabled: false };
     case ConfirmButtonState.DISABLED:


### PR DESCRIPTION
As the title suggests, I am adding a health bar to the borrow modal to show users what their health will look like after borrowing. Assuming it looks good, I plan to add this to the other modals (where need be). Along with the new health bar, I also cleaned up the logic that handles when the contract gets prepared and added new button states to give the user a more accurate description of the current state. Below is an image of the updated modal:
<img width="506" alt="Screenshot 2023-04-03 at 9 48 08 PM" src="https://user-images.githubusercontent.com/17186604/229665579-e1b3e784-12a1-4bf1-8eab-b559a4f3b61b.png">

