### PR TITLE
Adding a better formatting function for the market card

### DIFF
--- a/earn/src/components/lend/LendPairCard.tsx
+++ b/earn/src/components/lend/LendPairCard.tsx
@@ -32,7 +32,7 @@ const TokenAPYWrapper = styled.div`
 
 const CustomBodySubContainer = styled(BodySubContainer)`
   position: relative;
-  padding-right: 80px;
+  padding-right: 40px;
 `;
 
 const CardActionButton = styled.button`

--- a/earn/src/components/lend/LendTokenInfo.tsx
+++ b/earn/src/components/lend/LendTokenInfo.tsx
@@ -1,9 +1,10 @@
 import InfoFigure from 'shared/lib/components/common/InfoFigure';
 
 import { Token } from '../../data/Token';
-import { roundPercentage, formatTokenAmount, formatUSDAuto } from '../../util/Numbers';
+import { roundPercentage, formatUSDAuto, formatAmountWithUnit } from '../../util/Numbers';
 
 const FIGURE_COLOR = 'rgba(255, 255, 255, 0.6)';
+const MAX_CHARACTERS = 10;
 
 export type LendTokenInfoProps = {
   token?: Token;
@@ -17,7 +18,7 @@ export default function LendTokenInfo(props: LendTokenInfoProps) {
   return (
     <InfoFigure
       label0='Total Supply'
-      value0={token ? `${formatTokenAmount(totalSupply)} ${token.ticker}` : formatUSDAuto(totalSupply)}
+      value0={token ? `${formatAmountWithUnit(totalSupply, token.ticker, MAX_CHARACTERS)}` : formatUSDAuto(totalSupply)}
       label1='Utilization'
       value1={`${roundPercentage(utilization)}%`}
       figureColor={FIGURE_COLOR}

--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -237,6 +237,8 @@ export function formatAmountWithUnit(amount: number, unit: string, maxLength = 1
       minimumFractionDigits: 1,
       maximumFractionDigits: 1,
     })} ${unit}`;
+  } else if (amount === 0) {
+    return `0 ${unit}`;
   } else if (amount < Math.pow(10, -4)) {
     // Use scientific notation for small numbers
     return `${amount.toLocaleString('en-US', {

--- a/earn/src/util/Numbers.ts
+++ b/earn/src/util/Numbers.ts
@@ -140,20 +140,20 @@ export function formatTokenAmount(amount: number, sigDigs = 4): string {
       notation: 'compact',
       compactDisplay: 'short',
       maximumSignificantDigits: sigDigs,
-      minimumSignificantDigits: 2,
+      minimumSignificantDigits: Math.min(2, sigDigs),
     });
   } else if (amount > 1e-5 || amount === 0) {
     return amount.toLocaleString('en-US', {
       style: 'decimal',
       maximumSignificantDigits: sigDigs,
-      minimumSignificantDigits: 2,
+      minimumSignificantDigits: Math.min(2, sigDigs),
     });
   } else if (amount > 1e-10) {
     return amount.toLocaleString('en-US', {
       style: 'decimal',
       notation: 'scientific',
       maximumSignificantDigits: sigDigs,
-      minimumSignificantDigits: 2,
+      minimumSignificantDigits: Math.min(2, sigDigs),
     });
   } else {
     // If amount <= 10e-10, we want to show no more than 2 sigdigs
@@ -217,6 +217,39 @@ export function formatPriceRatio(x: number, sigDigs = 4): string {
   } else {
     return '0';
   }
+}
+
+/**
+ * Formats an amount with a unit, abbreviating large numbers and using scientific notation for small numbers.
+ * Note: This function may not work properly if the unit close to or longer than the maximum length.
+ * @param amount the amount to format
+ * @param unit the unit to append to the amount
+ * @param maxLength the maximum length of the formatted string
+ * @returns the formatted string
+ */
+export function formatAmountWithUnit(amount: number, unit: string, maxLength = 10): string {
+  const maxLengthOfAmount = maxLength - unit.length - 1;
+  if (amount > 10_000) {
+    // Abbreviate large numbers
+    return `${amount.toLocaleString('en-US', {
+      notation: 'compact',
+      compactDisplay: 'short',
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })} ${unit}`;
+  } else if (amount < Math.pow(10, -4)) {
+    // Use scientific notation for small numbers
+    return `${amount.toLocaleString('en-US', {
+      notation: 'scientific',
+      compactDisplay: 'short',
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })} ${unit}`;
+  }
+  // Otherwise, truncate decimals
+  const numDigits = Math.max(Math.floor(Math.log10(Math.abs(amount))), 0);
+  const numDecimals = Math.max(maxLengthOfAmount - numDigits, 0);
+  return `${truncateDecimals(amount.toString(), numDecimals)} ${unit}`;
 }
 
 export function areWithinNSigDigs(a: Big, b: Big, n: number): boolean {


### PR DESCRIPTION
Currently, the formatting for amounts on the market page is inconsistent and error-prone. This PR aims to address most of the issues, especially those involving the overflow of amounts on the markets page. This new approach involves mapping amounts into three categories, abbreviated, normal, and scientific notation. Abbreviated is for numbers bigger than a certain threshold, currently 10,000, and abbreviated the amounts using K to denote thousand, M to denote million, B to denote billion, and so on. Normal numbers are those that are not too small or too large and, with a bit of truncating, can be shown easily. Lastly, scientific notation is used to format numbers smaller than a certain threshold, currently 10^-4, so that we don't end up with needlessly long numbers that describe extremely small amounts. For example, 0.0000001 would be displayed as 1e-7. Additionally, I took the liberty of decreasing the padding on the right side of the stats. I feel that this is an easy way to give the amounts more room. The reason we originally had the extra padding was to give the edit button more room, but looking at it now, it doesn't seem too bad without the extra padding, and I feel the benefits are greater here.

<img width="1354" alt="Screenshot 2023-04-03 at 12 54 47 PM" src="https://user-images.githubusercontent.com/17186604/229578382-9fce2454-bbe3-4c08-ab69-cd17e08aa877.png">
<img width="1354" alt="Screenshot 2023-04-03 at 12 35 47 PM" src="https://user-images.githubusercontent.com/17186604/229578506-a4329713-83c7-4fb6-801c-2437e75963b3.png">
