### PR TITLE
Adding health bar to repay modal on earn

### DIFF
--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -609,6 +609,7 @@ export default function BorrowPage() {
           />
           <RepayModal
             marginAccount={selectedMarginAccount}
+            uniswapPositions={uniswapPositions}
             isOpen={isRepayModalOpen}
             setIsOpen={setIsRepayModalOpen}
             setPendingTxn={setPendingTxn}


### PR DESCRIPTION
As the title suggests, I am adding the health bar to the repay modal to show the user what their health will be upon repaying to help users understand how to make their account healthier. The styling is the same as the other modals.