### PR TITLE
Adding error msg if liquidity chart doesn't have data

### DIFF
--- a/prime/src/components/borrow/actions/UniswapAddLiquidityActionCard.tsx
+++ b/prime/src/components/borrow/actions/UniswapAddLiquidityActionCard.tsx
@@ -29,6 +29,7 @@ import TokenAmountInput from '../../common/TokenAmountInput';
 import TokenChooser from '../../common/TokenChooser';
 import { BaseActionCard } from '../BaseActionCard';
 import LiquidityChart, { ChartEntry } from '../uniswap/LiquidityChart';
+import LiquidityChartNotAvailable from '../uniswap/LiquidityChartNotAvailable';
 import { LiquidityChartPlaceholder } from '../uniswap/LiquidityChartPlaceholder';
 import SteppedInput from '../uniswap/SteppedInput';
 
@@ -69,6 +70,7 @@ export default function UniswapAddLiquidityActionCard(props: ActionCardProps) {
   const [uniswapPoolBasics, setUniswapPoolBasics] = useState<UniswapV3PoolBasics | null>(null);
   const [liquidityData, setLiquidityData] = useState<TickData[] | null>(null);
   const [chartData, setChartData] = useState<ChartEntry[]>([]);
+  const [chartLoading, setChartLoading] = useState(true);
 
   // MARK: pre-compute some useful stuff
   const poolAddress = getPoolAddressFromTokens(token0, token1, feeTier, activeChain.id);
@@ -143,6 +145,7 @@ export default function UniswapAddLiquidityActionCard(props: ActionCardProps) {
       return { price: isToken0Selected ? td.price0In1 : td.price1In0, liquidityDensity: td.totalValueIn0 };
     });
     setChartData(_chartData);
+    setChartLoading(false);
   }, [liquidityData, isToken0Selected]);
 
   /**
@@ -394,7 +397,9 @@ export default function UniswapAddLiquidityActionCard(props: ActionCardProps) {
           />
         )}
       </div>
-      {chartData.length === 0 || !ticksAreDefined ? (
+      {chartData.length === 0 && !chartLoading ? (
+        <LiquidityChartNotAvailable />
+      ) : chartData.length === 0 || !ticksAreDefined ? (
         <LiquidityChartPlaceholder />
       ) : (
         <LiquidityChart

--- a/prime/src/components/borrow/uniswap/LiquidityChartNotAvailable.tsx
+++ b/prime/src/components/borrow/uniswap/LiquidityChartNotAvailable.tsx
@@ -1,0 +1,41 @@
+import { Text } from 'shared/lib/components/common/Typography';
+import styled from 'styled-components';
+import tw from 'twin.macro';
+
+import { ReactComponent as AlertTriangleIcon } from '../../../assets/svg/alert_triangle.svg';
+
+const Container = styled.div`
+  ${tw`flex flex-col items-start justify-evenly`}
+  max-width: 350px;
+  width: 100%;
+  height: 227px;
+  margin-top: 3px;
+  margin-bottom: 20px;
+  background: #0d171e;
+`;
+
+const AlertTriangleIconStyled = styled(AlertTriangleIcon)`
+  width: 32px;
+  height: 32px;
+  margin-bottom: 8px;
+
+  path {
+    fill: #ff7a00;
+  }
+`;
+
+export default function LiquidityChartNotAvailable() {
+  return (
+    <Container>
+      <div className='flex flex-col items-center justify-evenly w-full'>
+        <AlertTriangleIconStyled />
+        <Text size='M' className='text-center'>
+          No chart available for this pair.
+        </Text>
+        <Text size='M' color='rgba(130, 160, 182, 1)' className='text-center'>
+          This does not affect your ability to add liquidity.
+        </Text>
+      </div>
+    </Container>
+  );
+}


### PR DESCRIPTION
Currently, if there is no data for the liquidity chart, as is the case on Arbitrum, the chart will load indefinitely. This can lead to confusion among users as it is unclear what is happening. To address this, I made it so that the chart will disappear instead of loading forever if there is no chart data for a specific pool. Below is an image of the updated component:
<img width="526" alt="Screenshot 2023-04-12 at 11 24 11 PM" src="https://user-images.githubusercontent.com/17186604/231641027-48e32a85-9a9e-48f9-b380-31249afb8bf5.png">

