### PR TITLE
Adding etherscan link to borrow page on earn

### DIFF
--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -31,7 +31,7 @@ export type Liabilities = {
  * For the use-cases that require all of the data
  */
 export type MarginAccount = {
-  address: string;
+  address: Address;
   uniswapPool: string;
   token0: Token;
   token1: Token;

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -9,7 +9,6 @@ import { useNavigate } from 'react-router-dom';
 import AppPage from 'shared/lib/components/common/AppPage';
 import { Text } from 'shared/lib/components/common/Typography';
 import { GetNumericFeeTier } from 'shared/lib/data/FeeTier';
-import useMediaQuery from 'shared/lib/data/hooks/UseMediaQuery';
 import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
 import styled from 'styled-components';
 import { Address, useAccount, useContract, useProvider, useContractRead } from 'wagmi';
@@ -20,7 +19,6 @@ import MarginAccountABI from '../assets/abis/MarginAccount.json';
 import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import { ReactComponent as InfoIcon } from '../assets/svg/info.svg';
-import { ReactComponent as OpenIcon } from '../assets/svg/open.svg';
 import BorrowGraph, { BorrowGraphData } from '../components/borrow/BorrowGraph';
 import { BorrowMetrics } from '../components/borrow/BorrowMetrics';
 import GlobalStatsTable from '../components/borrow/GlobalStatsTable';
@@ -41,11 +39,7 @@ import {
   ALOE_II_ORACLE_ADDRESS,
   UNISWAP_POOL_DENYLIST,
 } from '../data/constants/Addresses';
-import {
-  RESPONSIVE_BREAKPOINTS,
-  RESPONSIVE_BREAKPOINT_MD,
-  RESPONSIVE_BREAKPOINT_SM,
-} from '../data/constants/Breakpoints';
+import { RESPONSIVE_BREAKPOINT_MD, RESPONSIVE_BREAKPOINT_SM } from '../data/constants/Breakpoints';
 import { TOPIC0_CREATE_MARKET_EVENT, TOPIC0_IV } from '../data/constants/Signatures';
 import { PRIME_URL } from '../data/constants/Values';
 import { useDebouncedEffect } from '../data/hooks/UseDebouncedEffect';
@@ -60,7 +54,6 @@ import {
   UniswapPosition,
   UniswapPositionPrior,
 } from '../data/Uniswap';
-import { truncateAddress } from '../util/Addresses';
 import { makeEtherscanRequest } from '../util/Etherscan';
 
 const BORROW_TITLE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
@@ -88,12 +81,13 @@ const Container = styled.div`
 const PageGrid = styled.div`
   display: grid;
   grid-template-columns: 1fr 1.2fr;
-  grid-template-rows: auto auto auto;
+  grid-template-rows: auto auto auto auto auto;
   grid-template-areas:
     'monitor graph'
     'metrics metrics'
     'uniswap uniswap'
-    'stats stats';
+    'stats stats'
+    'link link';
   flex-grow: 1;
   margin-top: 26px;
 
@@ -106,7 +100,8 @@ const PageGrid = styled.div`
       'graph'
       'metrics'
       'uniswap'
-      'stats';
+      'stats'
+      'link';
   }
 `;
 
@@ -120,12 +115,6 @@ const StyledExternalLink = styled.a`
   max-width: 100%;
   &:hover {
     text-decoration: underline;
-  }
-`;
-
-const StyledOpenIcon = styled(OpenIcon)`
-  path {
-    stroke: ${LABEL_TEXT_COLOR};
   }
 `;
 
@@ -172,6 +161,14 @@ const UniswapPositionsContainer = styled.div`
 
 const StatsContainer = styled.div`
   grid-area: stats;
+`;
+
+const LinkContainer = styled.div`
+  grid-area: link;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
 `;
 
 export type UniswapPoolInfo = {
@@ -469,8 +466,6 @@ export default function BorrowPage() {
     };
   }, [pendingTxn]);
 
-  const isBiggerThanMobile = useMediaQuery(RESPONSIVE_BREAKPOINTS['SM']);
-
   const filteredNonZeroUniswapNFTPositions = useMemo(() => {
     const filteredPositions: Map<number, UniswapNFTPosition> = new Map();
     if (selectedMarginAccount == null) return filteredPositions;
@@ -602,29 +597,16 @@ export default function BorrowPage() {
           <StatsContainer>
             <GlobalStatsTable marginAccount={selectedMarginAccount} marketInfo={selectedMarketInfo} />
           </StatsContainer>
-        </PageGrid>
-      </Container>
-      {selectedMarginAccount &&
-        (isBiggerThanMobile ? (
-          <div className='flex justify-center items-center gap-1 overflow-clip'>
+          <LinkContainer>
             <InfoIcon width={16} height={16} />
             <Text size='S' color={BORROW_TITLE_TEXT_COLOR} className='flex gap-1 whitespace-nowrap'>
-              View this account on Etherscan:{' '}
               <StyledExternalLink href={selectedMarginAccountEtherscanUrl} target='_blank'>
-                {selectedMarginAccountEtherscanUrl}
+                View this account on Etherscan
               </StyledExternalLink>
             </Text>
-          </div>
-        ) : (
-          <div className='flex justify-center items-center gap-1'>
-            <Text size='S' color={LABEL_TEXT_COLOR} className='flex gap-1 whitespace-nowrap'>
-              <StyledExternalLink href={selectedMarginAccountEtherscanUrl} target='_blank'>
-                {truncateAddress(selectedMarginAccount.address, 32)}
-              </StyledExternalLink>
-            </Text>
-            <StyledOpenIcon width={16} height={16} />
-          </div>
-        ))}
+          </LinkContainer>
+        </PageGrid>
+      </Container>
       {availablePools.size > 0 && (
         <NewSmartWalletModal
           availablePools={availablePools}


### PR DESCRIPTION
While I am not completely satisfied with how this looks, I think it is a good start and enables users to navigate to their smart wallet on Etherscan more easily. The link will use the correct block explorer for the active chain.
I added separate styling for mobile and desktop:
<img width="1512" alt="Screenshot 2023-04-14 at 9 59 54 AM" src="https://user-images.githubusercontent.com/17186604/232066858-e39fb234-1ab4-4b72-99ab-11940b79d547.png">
<img width="369" alt="Screenshot 2023-04-14 at 10 00 34 AM" src="https://user-images.githubusercontent.com/17186604/232066865-ea790798-e481-40c4-a21b-33e06e976c54.png">
