### PR TITLE
Fixing NaN for uniswap position

### DIFF
--- a/earn/src/components/borrow/UniswapPositionList.tsx
+++ b/earn/src/components/borrow/UniswapPositionList.tsx
@@ -148,8 +148,8 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
   const amount0InTermsOfToken1 = amount0 * token0PerToken1;
   const totalValue = amount0InTermsOfToken1 + amount1;
 
-  const amount0Percent = (amount0InTermsOfToken1 / totalValue) * 100;
-  const amount1Percent = (amount1 / totalValue) * 100;
+  const amount0Percent = totalValue > 0 ? (amount0InTermsOfToken1 / totalValue) * 100 : 0;
+  const amount1Percent = totalValue > 0 ? (amount1 / totalValue) * 100 : 0;
 
   const currentTick = sqrtRatioToTick(sqrtPriceX96);
 


### PR DESCRIPTION
Currently, if the total value of a Uniswap position is zero, the percentages of each asset will show `NaN`. This PR addresses that by making the percentages zero in this case.