### PR TITLE
Fixing the lend withdraw modal logic, adding proper gas estimation

### DIFF
--- a/earn/src/components/common/TokenAmountInput.tsx
+++ b/earn/src/components/common/TokenAmountInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Big from 'big.js';
 import { SquareInputWithMax } from 'shared/lib/components/common/Input';
 import { Text } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
@@ -65,7 +66,7 @@ export default function TokenAmountInput(props: TokenAmountInputProps) {
         value={value}
         onMaxClick={() => {
           if (max) {
-            onMax ? onMax(max) : onChange(max.toString());
+            onMax ? onMax(max) : onChange(new Big(max.toString()).toFixed());
           }
         }}
         maxDisabled={maxed}

--- a/earn/src/components/lend/modal/content/WithdrawModalContent.tsx
+++ b/earn/src/components/lend/modal/content/WithdrawModalContent.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 
 import { SendTransactionResult } from '@wagmi/core';
 import Big from 'big.js';
-import { BigNumber, ethers } from 'ethers';
+import { BigNumber } from 'ethers';
 import { FilledStylizedButton } from 'shared/lib/components/common/Buttons';
 import { Text } from 'shared/lib/components/common/Typography';
 import { useAccount, useContractRead, useContractWrite, usePrepareContractWrite } from 'wagmi';
@@ -55,7 +55,7 @@ type WithdrawButtonProps = {
 };
 
 function WithdrawButton(props: WithdrawButtonProps) {
-  const { withdrawAmount, maxWithdrawBalance, maxRedeemBalance, token, kitty, accountAddress, setPendingTxn } = props;
+  const { withdrawAmount, maxWithdrawBalance, maxRedeemBalance, kitty, accountAddress, setPendingTxn } = props;
   const { activeChain } = useContext(ChainContext);
   const [isPending, setIsPending] = useState(false);
 
@@ -64,7 +64,7 @@ function WithdrawButton(props: WithdrawButtonProps) {
     address: kitty.address,
     abi: KittyABI,
     functionName: 'convertToShares',
-    args: [ethers.utils.parseUnits(withdrawAmount.toFixed(token.decimals), token.decimals)],
+    args: [withdrawAmount.toFixed(0)],
     chainId: activeChain.id,
   }) as { data: BigNumber | undefined; isLoading: boolean };
 


### PR DESCRIPTION
Currently, the withdraw modal doesn't handle small values properly because they are sometimes represented in scientific notation. To remedy this, I updated the logic to utilize Big's whenever possible, and when we converted them to strings, I made sure we used .toFixed(). Additionally, I added proper gas estimation rather than relying on hardcoded values.