### PR TITLE
Fixing max withdraw not letting user click

### DIFF
--- a/earn/src/data/hooks/UseRedeem.ts
+++ b/earn/src/data/hooks/UseRedeem.ts
@@ -63,11 +63,13 @@ export function useRedeem(chainId: number, lender: Address, amount: GN, owner: A
   });
   const [maxAmount, maxShares, maxSharesIsChanging] = maxData ?? [BN0, BN0, false];
 
+  // If the user is trying to redeem more than they can, we'll just redeem the max.
+  // This means we won't refetch multiple times if the user enters a number greater than the max.
+  const amountToConvert = amount.toBigNumber().lte(maxAmount) ? amount : GN.Q(112);
   const { data: sharesData, isFetching: isFetchingShares } = useContractRead({
     ...erc4626,
     functionName: 'convertToShares',
-    args: [amount.toBigNumber()],
-    enabled: amount.toBigNumber().lte(maxAmount) || amount.eq(GN.Q(112)),
+    args: [amountToConvert.toBigNumber()],
   });
   const shares = sharesData ?? BN0;
 

--- a/earn/src/data/hooks/UseRedeem.ts
+++ b/earn/src/data/hooks/UseRedeem.ts
@@ -67,7 +67,7 @@ export function useRedeem(chainId: number, lender: Address, amount: GN, owner: A
     ...erc4626,
     functionName: 'convertToShares',
     args: [amount.toBigNumber()],
-    enabled: amount.toBigNumber().lte(maxAmount),
+    enabled: amount.toBigNumber().lte(maxAmount) || amount.eq(GN.Q(112)),
   });
   const shares = sharesData ?? BN0;
 


### PR DESCRIPTION
Recently, we introduced logic to disable the `convertToShares` fetch if the amount input is greater than the user's balance. While this logic is correct, it didn't take the max button's implementation into account. When the user clicks the max button, we pass Q112 as the amount to indicate the user wants to completely drain the account. However, Q112 is greater than the user's balance causing the `convertToShares` fetch to remain disabled and stopping the entire flow in its tracks. To fix this, I added an additional check for whether the amount is equal to Q112, in which case we enable the `convertToShares` fetch. While this works, I do think we could use a constant that is used by both the logic that sets the max value to Q112 and the check to see if the amount is equal to it so that we don't accidentally only change one of them at some point in the future.