### PR TITLE
Starting to remove our etherscan api dependency

### DIFF
--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -178,13 +178,13 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
       let lender1Logs: ethers.providers.Log[] = [];
       try {
         [lender0Logs, lender1Logs] = await Promise.all([
-          await provider.getLogs({
+          provider.getLogs({
             fromBlock: 0,
             toBlock: 'latest',
             address: selectedLendingPair.kitty0.address,
             topics: ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
           }),
-          await provider.getLogs({
+          provider.getLogs({
             fromBlock: 0,
             toBlock: 'latest',
             address: selectedLendingPair.kitty1.address,
@@ -194,8 +194,9 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
       } catch (error) {
         console.error(error);
       }
-      if (lender0Logs == null || !Array.isArray(lender0Logs) || lender1Logs == null || !Array.isArray(lender1Logs))
+      if (lender0Logs.length === 0 && lender1Logs.length === 0) {
         return;
+      }
       let uniqueUsers = new Set<string>();
       const logs = [...lender0Logs, ...lender1Logs];
       logs.forEach((log: ethers.providers.Log) => {

--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -1,16 +1,16 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 
-import { AxiosResponse } from 'axios';
+import { ethers } from 'ethers';
 import { Dropdown, DropdownOption } from 'shared/lib/components/common/Dropdown';
 import { Display, Text } from 'shared/lib/components/common/Typography';
 import { Token } from 'shared/lib/data/Token';
 import { formatTokenAmount, roundPercentage } from 'shared/lib/util/Numbers';
 import styled from 'styled-components';
+import { useProvider } from 'wagmi';
 
 import { ChainContext } from '../../App';
 import { RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
 import { LendingPair } from '../../data/LendingPair';
-import { makeEtherscanRequest } from '../../util/Etherscan';
 import Tooltip from '../common/Tooltip';
 
 const Container = styled.div`
@@ -142,6 +142,7 @@ export type LendingPairPeerCardProps = {
 export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
   const { activeAsset, lendingPairs } = props;
   const { activeChain } = useContext(ChainContext);
+  const provider = useProvider({ chainId: activeChain.id });
 
   const [cachedData, setCachedData] = useState<Map<string, number>>(new Map());
 
@@ -169,44 +170,37 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
       setNumberOfUsers(cachedResult);
       return;
     }
+    // Temporarily set the number of users to 0 while we fetch the number of users
+    setNumberOfUsers(0);
     // TODO: move this to a hook
     async function fetchNumberOfUsers() {
-      const etherscanRequestLender0 = makeEtherscanRequest(
-        0,
-        selectedLendingPair.kitty0.address,
-        ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
-        true,
-        activeChain
-      );
-      const etherscanRequestLender1 = makeEtherscanRequest(
-        0,
-        selectedLendingPair.kitty1.address,
-        ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
-        true,
-        activeChain
-      );
-      let etherscanResultLender0: AxiosResponse<any, any> | null = null;
-      let etherscanResultLender1: AxiosResponse<any, any> | null = null;
+      let lender0Logs: ethers.providers.Log[] = [];
+      let lender1Logs: ethers.providers.Log[] = [];
       try {
-        [etherscanResultLender0, etherscanResultLender1] = await Promise.all([
-          etherscanRequestLender0,
-          etherscanRequestLender1,
+        [lender0Logs, lender1Logs] = await Promise.all([
+          await provider.getLogs({
+            fromBlock: 0,
+            toBlock: 'latest',
+            address: selectedLendingPair.kitty0.address,
+            topics: ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
+          }),
+          await provider.getLogs({
+            fromBlock: 0,
+            toBlock: 'latest',
+            address: selectedLendingPair.kitty1.address,
+            topics: ['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'],
+          }),
         ]);
       } catch (error) {
         console.error(error);
       }
-      if (
-        etherscanResultLender0 == null ||
-        !Array.isArray(etherscanResultLender0.data.result) ||
-        etherscanResultLender1 == null ||
-        !Array.isArray(etherscanResultLender1.data.result)
-      )
+      if (lender0Logs == null || !Array.isArray(lender0Logs) || lender1Logs == null || !Array.isArray(lender1Logs))
         return;
       let uniqueUsers = new Set<string>();
-      const results = [...etherscanResultLender0.data.result, ...etherscanResultLender1.data.result];
-      results.forEach((result: any) => {
-        if (result.topics.length < 3) return;
-        const userAddress = `0x${result.topics[2].slice(26)}`;
+      const logs = [...lender0Logs, ...lender1Logs];
+      logs.forEach((log: ethers.providers.Log) => {
+        if (log.topics.length < 3) return;
+        const userAddress = `0x${log.topics[2].slice(26)}`;
         uniqueUsers.add(userAddress);
       });
       if (mounted) {
@@ -221,7 +215,7 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
     return () => {
       mounted = false;
     };
-  }, [selectedLendingPair, activeChain, cachedData, selectedOption.label]);
+  }, [selectedLendingPair, activeChain, cachedData, selectedOption.label, provider]);
 
   const [activeUtilization, activeTotalSupply] = getActiveUtilizationAndTotalSupply(activeAsset, selectedLendingPair);
 

--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -72,7 +72,7 @@ export async function getAvailableLendingPairs(
   } catch (e) {
     console.error(e);
   }
-  if (logs == null || !Array.isArray(logs)) return [];
+  if (logs.length === 0) return [];
 
   const addresses: { pool: string; kitty0: string; kitty1: string }[] = logs.map((item: any) => {
     return {

--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { ContractCallContext, Multicall } from 'ethereum-multicall';
 import { ethers } from 'ethers';
 import { FeeTier, NumericFeeTierToEnum } from 'shared/lib/data/FeeTier';
@@ -12,7 +11,6 @@ import KittyABI from '../assets/abis/Kitty.json';
 import KittyLensABI from '../assets/abis/KittyLens.json';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
-import { makeEtherscanRequest } from '../util/Etherscan';
 import { ContractCallReturnContextEntries, convertBigNumbersForReturnContexts } from '../util/Multicall';
 import {
   ALOE_II_FACTORY_ADDRESS,
@@ -63,21 +61,20 @@ export async function getAvailableLendingPairs(
   provider: ethers.providers.BaseProvider
 ): Promise<LendingPair[]> {
   const multicall = new Multicall({ ethersProvider: provider });
-  let etherscanResult: AxiosResponse<any, any> | null = null;
+  let logs: ethers.providers.Log[] = [];
   try {
-    etherscanResult = await makeEtherscanRequest(
-      7537163,
-      ALOE_II_FACTORY_ADDRESS,
-      ['0x3f53d2c2743b2b162c0aa5d678be4058d3ae2043700424be52c04105df3e2411'],
-      true,
-      chain
-    );
+    logs = await provider.getLogs({
+      fromBlock: 7537163,
+      toBlock: 'latest',
+      address: ALOE_II_FACTORY_ADDRESS,
+      topics: ['0x3f53d2c2743b2b162c0aa5d678be4058d3ae2043700424be52c04105df3e2411'],
+    });
   } catch (e) {
     console.error(e);
   }
-  if (etherscanResult == null || !Array.isArray(etherscanResult.data.result)) return [];
+  if (logs == null || !Array.isArray(logs)) return [];
 
-  const addresses: { pool: string; kitty0: string; kitty1: string }[] = etherscanResult.data.result.map((item: any) => {
+  const addresses: { pool: string; kitty0: string; kitty1: string }[] = logs.map((item: any) => {
     return {
       pool: item.topics[1].slice(26),
       kitty0: `0x${item.data.slice(26, 66)}`,

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -65,7 +65,7 @@ export async function getMarginAccountsForUser(
   } catch (e) {
     console.error(e);
   }
-  if (logs == null || !Array.isArray(logs)) return [];
+  if (logs.length === 0) return [];
 
   const accounts: { address: string; uniswapPool: string }[] = logs.map((item: any) => {
     return {

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -9,7 +9,6 @@ import { Address, Chain } from 'wagmi';
 import MarginAccountABI from '../assets/abis/MarginAccount.json';
 import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
 import VolatilityOracleABI from '../assets/abis/VolatilityOracle.json';
-import { makeEtherscanRequest } from '../util/Etherscan';
 import { ContractCallReturnContextEntries, convertBigNumbersForReturnContexts } from '../util/Multicall';
 import { ALOE_II_BORROWER_LENS_ADDRESS, ALOE_II_FACTORY_ADDRESS, ALOE_II_ORACLE_ADDRESS } from './constants/Addresses';
 import { TOPIC0_CREATE_BORROWER_EVENT } from './constants/Signatures';
@@ -52,20 +51,23 @@ export type MarginAccount = {
 export type MarginAccountPreview = Omit<MarginAccount, 'sqrtPriceX96' | 'lender0' | 'lender1' | 'iv'>;
 
 export async function getMarginAccountsForUser(
-  chain: Chain,
   userAddress: string,
   provider: ethers.providers.Provider
 ): Promise<{ address: string; uniswapPool: string }[]> {
-  const etherscanResult = await makeEtherscanRequest(
-    0,
-    ALOE_II_FACTORY_ADDRESS,
-    [TOPIC0_CREATE_BORROWER_EVENT, null, `0x000000000000000000000000${userAddress.slice(2)}`],
-    true,
-    chain
-  );
-  if (!Array.isArray(etherscanResult.data.result)) return [];
+  let logs: ethers.providers.Log[] = [];
+  try {
+    logs = await provider.getLogs({
+      fromBlock: 0,
+      toBlock: 'latest',
+      address: ALOE_II_FACTORY_ADDRESS,
+      topics: [TOPIC0_CREATE_BORROWER_EVENT, null, `0x000000000000000000000000${userAddress.slice(2)}`],
+    });
+  } catch (e) {
+    console.error(e);
+  }
+  if (logs == null || !Array.isArray(logs)) return [];
 
-  const accounts: { address: string; uniswapPool: string }[] = etherscanResult.data.result.map((item: any) => {
+  const accounts: { address: string; uniswapPool: string }[] = logs.map((item: any) => {
     return {
       address: item.data.slice(0, 2) + item.data.slice(26),
       uniswapPool: item.topics[1].slice(26),
@@ -88,7 +90,7 @@ export async function fetchMarginAccounts(
   uniswapPoolDataMap: Map<string, UniswapPoolInfo>
 ): Promise<MarginAccount[]> {
   const multicall = new Multicall({ ethersProvider: provider, tryAggregate: true });
-  const marginAccountsAddresses = await getMarginAccountsForUser(chain, userAddress, provider);
+  const marginAccountsAddresses = await getMarginAccountsForUser(userAddress, provider);
   const marginAccountCallContext: ContractCallContext[] = [];
 
   // Fetch all the data for the margin accounts

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -223,18 +223,20 @@ export default function BorrowPage() {
   useEffect(() => {
     let mounted = true;
     async function fetchAvailablePools() {
-      const result = await makeEtherscanRequest(
-        0,
-        ALOE_II_FACTORY_ADDRESS,
-        [TOPIC0_CREATE_MARKET_EVENT],
-        false,
-        activeChain
-      );
-      const createMarketEvents = result.data.result;
+      let logs: ethers.providers.Log[] = [];
+      try {
+        logs = await provider.getLogs({
+          fromBlock: 0,
+          toBlock: 'latest',
+          address: ALOE_II_FACTORY_ADDRESS,
+          topics: [TOPIC0_CREATE_MARKET_EVENT],
+        });
+      } catch (e) {
+        console.error(e);
+      }
+      if (logs == null || !Array.isArray(logs)) return;
 
-      if (!Array.isArray(createMarketEvents)) return;
-
-      const poolAddresses = createMarketEvents
+      const poolAddresses = logs
         .map((e) => `0x${e.topics[1].slice(-40)}`)
         .filter((addr) => {
           return !UNISWAP_POOL_DENYLIST.includes(addr.toLowerCase());

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -234,7 +234,6 @@ export default function BorrowPage() {
       } catch (e) {
         console.error(e);
       }
-      if (logs == null || !Array.isArray(logs)) return;
 
       const poolAddresses = logs
         .map((e) => `0x${e.topics[1].slice(-40)}`)


### PR DESCRIPTION
The etherscan api has been a pain point for us as it has often been slow and even unresponsive at times. Moreover, it is not particularly scalable. This PR aims to start moving our code away from using etherscan and instead to using `eth_getLogs`. The one worry I have with this switch is issues arising from having too many logs and, thus possibly not getting the most updated data or even an error. That is why I chose to leave out the graph data fetching from this PR as it has the potential to grow to a size that may cause issues. Moreover, it does not block the rendering of the page meaning I am less worried about it taking a little longer. I do however hope to come back to this case in the future and properly address it.

I did my best to keep the logic roughly the same as before besides changing the etherscan API call with the `eth_getLogs`. I do plan on updating this logic more in the future, but I thought this would make for a good starting point.