### PR TITLE
Fix fetching when no account is present on markets page

### DIFF
--- a/earn/src/components/lend/modal/content/WithdrawModalContent.tsx
+++ b/earn/src/components/lend/modal/content/WithdrawModalContent.tsx
@@ -181,16 +181,23 @@ export default function WithdrawModalContent(props: WithdrawModalContentProps) {
 
   useEffect(() => {
     let interval: NodeJS.Timer | null = null;
-    interval = setInterval(() => {
-      refetchMaxRedeem();
-      refetchMaxWithdraw();
-    }, 13_000);
+    // Only poll if the user is connected
+    if (accountAddress !== undefined) {
+      interval = setInterval(() => {
+        refetchMaxRedeem();
+        refetchMaxWithdraw();
+      }, 13_000);
+    }
+    // If the user disconnects, stop polling
+    if (accountAddress === undefined && interval != null) {
+      clearInterval(interval);
+    }
     return () => {
       if (interval != null) {
         clearInterval(interval);
       }
     };
-  }, [refetchMaxRedeem, refetchMaxWithdraw]);
+  }, [accountAddress, refetchMaxRedeem, refetchMaxWithdraw]);
 
   return (
     <>


### PR DESCRIPTION
Currently, if the user is not connected, when they open the edit position modal, we fetch information about them which will not work. To combat this, I added restrictions around the initial and refetching of this data. Alternatively, we could not let them open the modals, but this could get complicated when we consider the scenario where a user disconnects. Also, it may not be clear to users that are just browsing the app how they would deposit unless they connected their wallet, which could impact users.