### PR TITLE
Hiding etherscan link when the user has no margin acount selected

### DIFF
--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -599,14 +599,16 @@ export default function BorrowPage() {
           <StatsContainer>
             <GlobalStatsTable marginAccount={selectedMarginAccount} marketInfo={selectedMarketInfo} />
           </StatsContainer>
-          <LinkContainer>
-            <InfoIcon width={16} height={16} />
-            <Text size='S' color={BORROW_TITLE_TEXT_COLOR} className='flex gap-1 whitespace-nowrap'>
-              <StyledExternalLink href={selectedMarginAccountEtherscanUrl} target='_blank'>
-                View this account on Etherscan
-              </StyledExternalLink>
-            </Text>
-          </LinkContainer>
+          {selectedMarginAccount && (
+            <LinkContainer>
+              <InfoIcon width={16} height={16} />
+              <Text size='S' color={BORROW_TITLE_TEXT_COLOR} className='flex gap-1 whitespace-nowrap'>
+                <StyledExternalLink href={selectedMarginAccountEtherscanUrl} target='_blank'>
+                  View this account on Etherscan
+                </StyledExternalLink>
+              </Text>
+            </LinkContainer>
+          )}
         </PageGrid>
       </Container>
       {availablePools.size > 0 && (


### PR DESCRIPTION
Currently, we show the etherscan link on the borrow page on the Earn site even if no account is selected. This PR addresses this by only showing this link if the user has an account selected.