### PR TITLE
Adding etherscan link to prime borrow actions page

### DIFF
--- a/prime/src/components/borrow/MarginAccountHeader.tsx
+++ b/prime/src/components/borrow/MarginAccountHeader.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import FeeTierContainer from 'shared/lib/components/common/FeeTierContainer';
 import RoundedBadge from 'shared/lib/components/common/RoundedBadge';
 import { Display } from 'shared/lib/components/common/Typography';
 import { Token } from 'shared/lib/data/Token';
+import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 
+import { ChainContext } from '../../App';
+import { ReactComponent as OpenIcon } from '../../assets/svg/open.svg';
 import {
   RESPONSIVE_BREAKPOINT_LG,
   RESPONSIVE_BREAKPOINT_SM,
@@ -61,6 +64,12 @@ const Wrapper = styled.div`
   }
 `;
 
+const MarginAccountLink = styled.a`
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 export type MarginAccountHeaderProps = {
   token0: Token;
   token1: Token;
@@ -69,6 +78,8 @@ export type MarginAccountHeaderProps = {
 };
 
 export default function MarginAccountHeader(props: MarginAccountHeaderProps) {
+  const { activeChain } = useContext(ChainContext);
+  const baseEtherscanUrl = getEtherscanUrlForChain(activeChain);
   return (
     <Wrapper>
       <MarginPairContainer>
@@ -88,7 +99,17 @@ export default function MarginAccountHeader(props: MarginAccountHeaderProps) {
       </MarginPairContainer>
       <MarginAccountBadges>
         <FeeTierContainer feeTier={props.feeTier} />
-        <RoundedBadge title={props.id}>ID - {formatAddressStart(props.id)}</RoundedBadge>
+        <RoundedBadge title={props.id}>
+          <MarginAccountLink
+            href={`${baseEtherscanUrl}/address/${props.id}`}
+            target='_blank'
+            rel='noreferrer'
+            className='flex gap-1 items-top'
+          >
+            <span>{formatAddressStart(props.id, 8)}</span>
+            <OpenIcon />
+          </MarginAccountLink>
+        </RoundedBadge>
       </MarginAccountBadges>
     </Wrapper>
   );

--- a/prime/src/components/borrow/MarginAccountHeader.tsx
+++ b/prime/src/components/borrow/MarginAccountHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 
 import FeeTierContainer from 'shared/lib/components/common/FeeTierContainer';
-import RoundedBadge from 'shared/lib/components/common/RoundedBadge';
+import RoundedBadge, { BADGE_TEXT_COLOR } from 'shared/lib/components/common/RoundedBadge';
 import { Display } from 'shared/lib/components/common/Typography';
 import { Token } from 'shared/lib/data/Token';
 import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
@@ -70,6 +70,13 @@ const MarginAccountLink = styled.a`
   }
 `;
 
+const StyledOpenIcon = styled(OpenIcon)`
+  path {
+    // While it should have this color by default, it is worth explicitly setting it
+    stroke: ${BADGE_TEXT_COLOR};
+  }
+`;
+
 export type MarginAccountHeaderProps = {
   token0: Token;
   token1: Token;
@@ -104,10 +111,10 @@ export default function MarginAccountHeader(props: MarginAccountHeaderProps) {
             href={`${baseEtherscanUrl}/address/${props.id}`}
             target='_blank'
             rel='noreferrer'
-            className='flex gap-1 items-top'
+            className='flex items-top gap-1'
           >
             <span>{formatAddressStart(props.id, 8)}</span>
-            <OpenIcon />
+            <StyledOpenIcon width={16} height={16} />
           </MarginAccountLink>
         </RoundedBadge>
       </MarginAccountBadges>

--- a/shared/src/components/common/RoundedBadge.tsx
+++ b/shared/src/components/common/RoundedBadge.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Text } from './Typography';
 
-const BADGE_TEXT_COLOR = 'rgba(204, 223, 237, 1)';
+export const BADGE_TEXT_COLOR = 'rgba(204, 223, 237, 1)';
 
 const Wrapper = styled.div`
   display: flex;


### PR DESCRIPTION
Updating the prime borrow page to include a link to the associated margin account on Etherscan.

<img width="477" alt="image" src="https://user-images.githubusercontent.com/17186604/235482155-082d438b-821f-4794-aadf-6ad026877104.png">
<img width="477" alt="image" src="https://user-images.githubusercontent.com/17186604/235482181-0845615c-832f-4739-8898-5dad22303b80.png">

