### PR TITLE
Additions to GoodNumbers before adding it to prime

### DIFF
--- a/shared/src/data/GoodNumber.test.ts
+++ b/shared/src/data/GoodNumber.test.ts
@@ -197,18 +197,18 @@ describe('GoodNumber', () => {
     it('should return true if two values are within N significant digits', () => {
       const a = GN.fromDecimalString('1', 18);
       const b = GN.fromDecimalString('1.000000000000000001', 18);
-      expect(GN.areWithinNSigDigs(a, b, 18)).toBe(true);
+      expect(GN.firstNSigDigsMatch(a, b, 18)).toBe(true);
       const c = GN.fromDecimalString('1.0235', 18);
       const d = GN.fromDecimalString('1.02', 18);
-      expect(GN.areWithinNSigDigs(c, d, 3)).toBe(true);
+      expect(GN.firstNSigDigsMatch(c, d, 3)).toBe(true);
     });
     it('should return false if two values are not within N significant digits', () => {
       const a = GN.fromDecimalString('1', 18);
       const b = GN.fromDecimalString('1.000000000000000001', 18);
-      expect(GN.areWithinNSigDigs(a, b, 19)).toBe(false);
+      expect(GN.firstNSigDigsMatch(a, b, 19)).toBe(false);
       const c = GN.fromDecimalString('1.0235', 18);
       const d = GN.fromDecimalString('1.02', 18);
-      expect(GN.areWithinNSigDigs(c, d, 4)).toBe(false);
+      expect(GN.firstNSigDigsMatch(c, d, 4)).toBe(false);
     });
   });
 

--- a/shared/src/data/GoodNumber.test.ts
+++ b/shared/src/data/GoodNumber.test.ts
@@ -375,7 +375,8 @@ describe('GoodNumber', () => {
 
   describe('one', () => {
     it('should return a one value', () => {
-      expect(GN.one(18).toString(GNFormat.INT)).toEqual('1');
+      expect(GN.one(18).toString(GNFormat.DECIMAL)).toEqual('1');
+      expect(GN.one(18).toString(GNFormat.INT)).toEqual('1000000000000000000');
     });
   });
 

--- a/shared/src/data/GoodNumber.test.ts
+++ b/shared/src/data/GoodNumber.test.ts
@@ -123,9 +123,55 @@ describe('GoodNumber', () => {
     it('should return false for 0', () => {
       expect(GN.fromDecimalString('0', 18).isGtZero()).toBe(false);
     });
+    it('should return false for negative values', () => {
+      expect(GN.fromDecimalString('-1', 18).isGtZero()).toBe(false);
+      expect(GN.fromDecimalString('-0.000000000000000001', 18).isGtZero()).toBe(false);
+    });
     it('should return true for non-zero values', () => {
       expect(GN.fromDecimalString('1', 18).isGtZero()).toBe(true);
       expect(GN.fromDecimalString('0.000000000000000001', 18).isGtZero()).toBe(true);
+    });
+  });
+
+  describe('isGteZero', () => {
+    it('should return true for 0', () => {
+      expect(GN.fromDecimalString('0', 18).isGteZero()).toBe(true);
+    });
+    it('should return true for non-zero values', () => {
+      expect(GN.fromDecimalString('1', 18).isGteZero()).toBe(true);
+      expect(GN.fromDecimalString('0.000000000000000001', 18).isGteZero()).toBe(true);
+    });
+    it('should return false for negative values', () => {
+      expect(GN.fromDecimalString('-1', 18).isGteZero()).toBe(false);
+      expect(GN.fromDecimalString('-0.000000000000000001', 18).isGteZero()).toBe(false);
+    });
+  });
+
+  describe('isLtZero', () => {
+    it('should return false for 0', () => {
+      expect(GN.fromDecimalString('0', 18).isLtZero()).toBe(false);
+    });
+    it('should return false for non-zero values', () => {
+      expect(GN.fromDecimalString('1', 18).isLtZero()).toBe(false);
+      expect(GN.fromDecimalString('0.000000000000000001', 18).isLtZero()).toBe(false);
+    });
+    it('should return true for negative values', () => {
+      expect(GN.fromDecimalString('-1', 18).isLtZero()).toBe(true);
+      expect(GN.fromDecimalString('-0.000000000000000001', 18).isLtZero()).toBe(true);
+    });
+  });
+
+  describe('isLteZero', () => {
+    it('should return true for 0', () => {
+      expect(GN.fromDecimalString('0', 18).isLteZero()).toBe(true);
+    });
+    it('should return false for non-zero values', () => {
+      expect(GN.fromDecimalString('1', 18).isLteZero()).toBe(false);
+      expect(GN.fromDecimalString('0.000000000000000001', 18).isLteZero()).toBe(false);
+    });
+    it('should return true for negative values', () => {
+      expect(GN.fromDecimalString('-1', 18).isLteZero()).toBe(true);
+      expect(GN.fromDecimalString('-0.000000000000000001', 18).isLteZero()).toBe(true);
     });
   });
 
@@ -144,6 +190,25 @@ describe('GoodNumber', () => {
       const b = GN.fromDecimalString('2', 18);
       expect(GN.min(a, b)).toEqual(a);
       expect(GN.min(b, a)).toEqual(a);
+    });
+  });
+
+  describe('areWithinNSigDigs', () => {
+    it('should return true if two values are within N significant digits', () => {
+      const a = GN.fromDecimalString('1', 18);
+      const b = GN.fromDecimalString('1.000000000000000001', 18);
+      expect(GN.areWithinNSigDigs(a, b, 18)).toBe(true);
+      const c = GN.fromDecimalString('1.0235', 18);
+      const d = GN.fromDecimalString('1.02', 18);
+      expect(GN.areWithinNSigDigs(c, d, 3)).toBe(true);
+    });
+    it('should return false if two values are not within N significant digits', () => {
+      const a = GN.fromDecimalString('1', 18);
+      const b = GN.fromDecimalString('1.000000000000000001', 18);
+      expect(GN.areWithinNSigDigs(a, b, 19)).toBe(false);
+      const c = GN.fromDecimalString('1.0235', 18);
+      const d = GN.fromDecimalString('1.02', 18);
+      expect(GN.areWithinNSigDigs(c, d, 4)).toBe(false);
     });
   });
 
@@ -305,6 +370,28 @@ describe('GoodNumber', () => {
   describe('zero', () => {
     it('should return a zero value', () => {
       expect(GN.zero(18).toString(GNFormat.DECIMAL)).toEqual('0');
+    });
+  });
+
+  describe('one', () => {
+    it('should return a one value', () => {
+      expect(GN.one(18).toString(GNFormat.INT)).toEqual('1');
+    });
+  });
+
+  describe('Q', () => {
+    it('should return a value of 2^N', () => {
+      expect(GN.Q(4).toString(GNFormat.INT)).toEqual('16');
+      expect(GN.Q(8).toString(GNFormat.INT)).toEqual('256');
+      expect(GN.Q(12).toString(GNFormat.INT)).toEqual('4096');
+      expect(GN.Q(16).toString(GNFormat.INT)).toEqual('65536');
+      expect(GN.Q(96).toString(GNFormat.INT)).toEqual('79228162514264337593543950336');
+    });
+    it('should throw an error if N is not a multiple of 4', () => {
+      expect(() => GN.Q(1)).toThrow();
+      expect(() => GN.Q(2)).toThrow();
+      expect(() => GN.Q(3)).toThrow();
+      expect(() => GN.Q(97)).toThrow();
     });
   });
 

--- a/shared/src/data/GoodNumber.ts
+++ b/shared/src/data/GoodNumber.ts
@@ -173,7 +173,7 @@ export class GN {
     return a.lt(b) ? a : b;
   }
 
-  static areWithinNSigDigs(a: GN, b: GN, n: number): boolean {
+  static firstNSigDigsMatch(a: GN, b: GN, n: number): boolean {
     return a.int.prec(n).eq(b.int.prec(n));
   }
 

--- a/shared/src/data/GoodNumber.ts
+++ b/shared/src/data/GoodNumber.ts
@@ -141,12 +141,40 @@ export class GN {
     return this.int.gt('0');
   }
 
+  /**
+   * Checks if the `GN` is greater than or equal to zero.
+   * @returns whether the `GN` is greater than or equal to zero.
+   */
+  isGteZero() {
+    return this.int.gte('0');
+  }
+
+  /**
+   * Checks if the `GN` is less than zero.
+   * @returns whether the `GN` is less than zero.
+   */
+  isLtZero() {
+    return this.int.lt('0');
+  }
+
+  /**
+   * Checks if the `GN` is less than or equal to zero.
+   * @returns whether the `GN` is less than or equal to zero.
+   */
+  isLteZero() {
+    return this.int.lte('0');
+  }
+
   static max(a: GN, b: GN) {
     return a.gt(b) ? a : b;
   }
 
   static min(a: GN, b: GN) {
     return a.lt(b) ? a : b;
+  }
+
+  static areWithinNSigDigs(a: GN, b: GN, n: number): boolean {
+    return a.int.prec(n).eq(b.int.prec(n));
   }
 
   /*//////////////////////////////////////////////////////////////
@@ -271,6 +299,10 @@ export class GN {
     return new GN('0', decimals, base);
   }
 
+  static one(decimals: number, base: 2 | 10 = 10) {
+    return new GN('1', decimals, base);
+  }
+
   static Q(resolution: number) {
     return new GN(scalerFor(2, resolution), resolution, 2);
   }
@@ -317,8 +349,7 @@ export class GN {
    * when expressing the number in standard notation.
    * @returns Equivalent `GN`
    */
-  static fromDecimalBig(x: Big, decimals: number) {
-    const base = 10;
+  static fromDecimalBig(x: Big, decimals: number, base: 2 | 10 = 10) {
     return new GN(x.mul(scalerFor(base, decimals)).toFixed(0), decimals, base);
   }
 
@@ -331,8 +362,8 @@ export class GN {
    * when expressing the number in standard notation.
    * @returns Equivalent `GN`
    */
-  static fromDecimalString(x: string, decimals: number) {
-    return GN.fromDecimalBig(new Big(x), decimals);
+  static fromDecimalString(x: string, decimals: number, base: 2 | 10 = 10) {
+    return GN.fromDecimalBig(new Big(x), decimals, base);
   }
 
   /**

--- a/shared/src/data/GoodNumber.ts
+++ b/shared/src/data/GoodNumber.ts
@@ -300,7 +300,7 @@ export class GN {
   }
 
   static one(decimals: number, base: 2 | 10 = 10) {
-    return new GN('1', decimals, base);
+    return new GN(scalerFor(base, decimals), decimals, base);
   }
 
   static Q(resolution: number) {

--- a/shared/src/data/GoodNumber.ts
+++ b/shared/src/data/GoodNumber.ts
@@ -349,7 +349,8 @@ export class GN {
    * when expressing the number in standard notation.
    * @returns Equivalent `GN`
    */
-  static fromDecimalBig(x: Big, decimals: number, base: 2 | 10 = 10) {
+  static fromDecimalBig(x: Big, decimals: number) {
+    const base = 10;
     return new GN(x.mul(scalerFor(base, decimals)).toFixed(0), decimals, base);
   }
 
@@ -362,8 +363,8 @@ export class GN {
    * when expressing the number in standard notation.
    * @returns Equivalent `GN`
    */
-  static fromDecimalString(x: string, decimals: number, base: 2 | 10 = 10) {
-    return GN.fromDecimalBig(new Big(x), decimals, base);
+  static fromDecimalString(x: string, decimals: number) {
+    return GN.fromDecimalBig(new Big(x), decimals);
   }
 
   /**


### PR DESCRIPTION
Added some new functionality to GoodNumbers in preparation for adding it to prime. 

- added the base argument to the `fromDecimalString` and `fromDecimalBig` functions.
- added `one` function to allow the user to easily create a `GN` with a value of 1.
- added `isGteZero`, `isLtZero`, and `isLteZero` as they will be useful.
- added `areWithinNSigDigs` as we use this with numbers that will most likely become `GN`s.
- added tests to get full coverage.