### PR TITLE
Adding 80% max button to withdraw modal

### DIFF
--- a/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
@@ -70,8 +70,13 @@ export function AloeWithdrawActionCard(prop: ActionCardProps) {
     token1.decimals
   );
 
+  const hasOutstandingBorrows = Object.values(accountState.liabilities).some((liability) => liability.isGtZero());
+
   const max = selectedTokenOption.value === TokenType.ASSET0 ? allowed0 : allowed1;
-  const maxString = max.toString(GNFormat.DECIMAL);
+  const eightyPercentMax = max.recklessMul(80).recklessDiv(100);
+  const maxString = hasOutstandingBorrows
+    ? eightyPercentMax.toString(GNFormat.DECIMAL)
+    : max.toString(GNFormat.DECIMAL);
 
   return (
     <BaseActionCard
@@ -96,6 +101,7 @@ export function AloeWithdrawActionCard(prop: ActionCardProps) {
           onChange={(value) => callbackWithFullResult(selectedToken, value)}
           max={maxString}
           maxed={tokenAmount === maxString}
+          maxButtonText={hasOutstandingBorrows ? '80% MAX' : undefined}
         />
       </div>
     </BaseActionCard>

--- a/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
@@ -77,6 +77,7 @@ export function AloeWithdrawActionCard(prop: ActionCardProps) {
   const maxString = hasOutstandingBorrows
     ? eightyPercentMax.toString(GNFormat.DECIMAL)
     : max.toString(GNFormat.DECIMAL);
+  const trueMaxString = max.toString(GNFormat.DECIMAL);
 
   return (
     <BaseActionCard
@@ -99,8 +100,9 @@ export function AloeWithdrawActionCard(prop: ActionCardProps) {
           token={selectedTokenOption.value === TokenType.ASSET0 ? token0 : token1}
           value={tokenAmount}
           onChange={(value) => callbackWithFullResult(selectedToken, value)}
-          max={maxString}
+          max={trueMaxString}
           maxed={tokenAmount === maxString}
+          onMax={() => callbackWithFullResult(selectedToken, maxString)}
           maxButtonText={hasOutstandingBorrows ? '80% MAX' : undefined}
         />
       </div>


### PR DESCRIPTION
Whenever the user has outstanding borrows, withdrawing max can put them very close to insolvency. To mitigate this, if the user has outstanding borrows, we populate the max amount with 80% of the max to give them a bit of leeway. If the user does not have outstanding borrows, the max is as it was previously.