### PR TITLE
Fixing window error

### DIFF
--- a/shared/src/util/Utils.ts
+++ b/shared/src/util/Utils.ts
@@ -7,7 +7,7 @@ export function isProduction() {
 }
 
 export function isDappnet() {
-  const url = window?.location?.href || '';
+  const url = typeof window !== 'undefined' ? window.location.href : '';
   return (
     process.env.REACT_APP_DEV_DAPPNET === 'true' ||
     ['https://aloe.eth/', 'https://earn.aloe.eth/', 'https://prime.aloe.eth/'].some((v) => url.startsWith(v))


### PR DESCRIPTION
Currently, the dappnet code (#426 and #427) causes errors on prime due to window not being defined. This PR aims to fix that by adding an additional check.