### PR TITLE
Adding more compact token inputs to action cards

### DIFF
--- a/prime/src/components/borrow/TokenAmountSelectInput.tsx
+++ b/prime/src/components/borrow/TokenAmountSelectInput.tsx
@@ -1,0 +1,89 @@
+import { ChangeEvent } from 'react';
+
+import { DropdownOption } from 'shared/lib/components/common/Dropdown';
+import { BaseMaxButton, InputBase } from 'shared/lib/components/common/Input';
+import { Text } from 'shared/lib/components/common/Typography';
+import styled from 'styled-components';
+
+import { TokenType } from '../../data/actions/Actions';
+import TokenDropdown from './TokenDropdown';
+
+const SquareInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border-radius: 8px;
+  input {
+    border-radius: 8px;
+  }
+  width: 100%;
+`;
+
+const TokenDropdownWrapper = styled.div`
+  position: absolute;
+  right: 7px;
+`;
+
+export type TokenAmountSelectInputProps = {
+  options: DropdownOption<TokenType>[];
+  selectedOption: DropdownOption<TokenType>;
+  inputValue: string;
+  maxAmount?: string;
+  maxAmountLabel?: string;
+  maxButtonLabel?: string;
+  onMax?: () => void;
+  onChange: (updatedValue: string) => void;
+  onSelect: (option: DropdownOption<TokenType>) => void;
+};
+
+export default function TokenAmountSelectInput(props: TokenAmountSelectInputProps) {
+  const { options, selectedOption, inputValue, maxAmount, maxAmountLabel, maxButtonLabel, onMax, onChange, onSelect } =
+    props;
+
+  return (
+    <div>
+      {maxAmount && (
+        <div className='w-full flex justify-between items-center mb-2'>
+          <Text size='XS' weight='medium' color='rgba(75, 105, 128,1)'>
+            {maxAmountLabel || 'Balance'}: {maxAmount}
+          </Text>
+          <BaseMaxButton
+            onClick={() => {
+              if (onMax) {
+                onMax();
+                return;
+              }
+              onChange(maxAmount);
+            }}
+          >
+            {maxButtonLabel || 'MAX'}
+          </BaseMaxButton>
+        </div>
+      )}
+      <SquareInputWrapper>
+        <InputBase
+          value={inputValue}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+          className={inputValue !== '' ? 'active' : ''}
+          inputSize='L'
+          fullWidth={true}
+          placeholder='0.00'
+          paddingRightOverride='164px'
+        />
+        <TokenDropdownWrapper>
+          <TokenDropdown
+            options={options}
+            onSelect={onSelect}
+            selectedOption={selectedOption}
+            size='S'
+            backgroundColor='rgba(43, 64, 80, 1)'
+            backgroundColorHover='rgb(75, 105, 128)'
+            compact={true}
+          />
+        </TokenDropdownWrapper>
+      </SquareInputWrapper>
+    </div>
+  );
+}

--- a/prime/src/components/borrow/TokenDropdown.tsx
+++ b/prime/src/components/borrow/TokenDropdown.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from 'react';
+
+import DropdownArrowDown from 'shared/lib/assets/svg/DropdownArrowDown';
+import DropdownArrowUp from 'shared/lib/assets/svg/DropdownArrowUp';
+import { DropdownOption } from 'shared/lib/components/common/Dropdown';
+import { Text } from 'shared/lib/components/common/Typography';
+import styled from 'styled-components';
+
+import { TokenType } from '../../data/actions/Actions';
+
+const UNKNOWN_TOKEN_ICON = '../../assets/svg/tokens/unknown_token.svg';
+const DEFAULT_BACKGROUND_COLOR = 'rgb(13, 23, 30)';
+const DEFAULT_BACKGROUND_COLOR_HOVER = 'rgb(18, 32, 41)';
+const DROPDOWN_HEADER_BORDER_COLOR = 'rgba(34, 54, 69, 1)';
+const DROPDOWN_LIST_SHADOW_COLOR = 'rgba(0, 0, 0, 0.12)';
+const DROPDOWN_PADDING_SIZES = {
+  S: '8px 38px 8px 12px',
+  M: '10px 40px 10px 16px',
+  L: '12px 42px 12px 20px',
+};
+
+const DropdownWrapper = styled.div.attrs((props: { compact?: boolean }) => props)`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  justify-content: space-evenly;
+  position: relative;
+  overflow: visible;
+  width: ${(props) => (props.compact ? 'max-content' : '100%')};
+`;
+
+const DropdownHeader = styled.button.attrs(
+  (props: { size: 'S' | 'M' | 'L'; backgroundColor?: string; compact?: boolean }) => props
+)`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${(props) => DROPDOWN_PADDING_SIZES[props.size]};
+  width: ${(props) => (props.compact ? 'max-content' : '100%')};
+  background-color: ${(props) => props.backgroundColor || DEFAULT_BACKGROUND_COLOR};
+  border: 1px solid ${DROPDOWN_HEADER_BORDER_COLOR};
+  border-radius: 8px;
+  cursor: pointer;
+  &.active {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+`;
+
+const DropdownList = styled.div.attrs((props: { backgroundColor?: string }) => props)`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  min-width: 100%;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  z-index: 1;
+  background-color: ${(props) => props.backgroundColor || DEFAULT_BACKGROUND_COLOR};
+  border: 1px solid ${DROPDOWN_HEADER_BORDER_COLOR};
+  border-top: 0;
+  box-shadow: 0px 4px 8px ${DROPDOWN_LIST_SHADOW_COLOR};
+`;
+
+const DropdownListItem = styled.button.attrs(
+  (props: { size: 'S' | 'M' | 'L'; backgroundColor?: string; backgroundColorHover?: string }) => props
+)`
+  text-align: start;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  white-space: nowrap;
+  width: 100%;
+  background-color: ${(props) => props.backgroundColor || DEFAULT_BACKGROUND_COLOR};
+  padding: ${(props) => DROPDOWN_PADDING_SIZES[props.size]};
+  cursor: pointer;
+
+  &:last-child {
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+  }
+  &:hover {
+    background-color: ${(props) => props.backgroundColorHover || DEFAULT_BACKGROUND_COLOR_HOVER};
+  }
+`;
+
+const TokenIcon = styled.img`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: white;
+`;
+
+export type TokenDropdownProps = {
+  options: DropdownOption<TokenType>[];
+  selectedOption: DropdownOption<TokenType>;
+  onSelect: (option: DropdownOption<TokenType>) => void;
+  size: 'S' | 'M' | 'L';
+  backgroundColor?: string;
+  backgroundColorHover?: string;
+  compact?: boolean;
+};
+
+export default function TokenDropdown(props: TokenDropdownProps) {
+  const { options, selectedOption, onSelect, size, backgroundColor, backgroundColorHover, compact } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  });
+
+  return (
+    <DropdownWrapper ref={dropdownRef} compact={compact}>
+      <DropdownHeader
+        onClick={() => setIsOpen(!isOpen)}
+        size={size}
+        backgroundColor={backgroundColor}
+        compact={compact}
+        className={isOpen ? 'active' : ''}
+      >
+        <div className='flex items-center gap-1'>
+          {typeof selectedOption.icon === 'string' ? (
+            <TokenIcon src={selectedOption.icon || UNKNOWN_TOKEN_ICON} width={20} height={20} />
+          ) : (
+            selectedOption.icon
+          )}
+          <Text size='M' weight='bold'>
+            {selectedOption.label}
+          </Text>
+        </div>
+        {isOpen ? (
+          <DropdownArrowUp className='w-5 absolute right-3' />
+        ) : (
+          <DropdownArrowDown className='w-5 absolute right-3' />
+        )}
+      </DropdownHeader>
+      {isOpen && (
+        <DropdownList backgroundColor={backgroundColor}>
+          {options.map((option) => (
+            <DropdownListItem
+              key={option.value}
+              onClick={() => {
+                onSelect(option);
+                setIsOpen(false);
+              }}
+              size={size}
+              backgroundColor={backgroundColor}
+              backgroundColorHover={backgroundColorHover}
+            >
+              <div className='flex items-center gap-1 min-w-max'>
+                {typeof option.icon === 'string' ? (
+                  <TokenIcon src={option.icon || UNKNOWN_TOKEN_ICON} width={20} height={20} />
+                ) : (
+                  option.icon
+                )}
+                <Text size='M' weight='bold'>
+                  {option.label}
+                </Text>
+              </div>
+            </DropdownListItem>
+          ))}
+        </DropdownList>
+      )}
+    </DropdownWrapper>
+  );
+}

--- a/prime/src/components/borrow/actions/AloeAddMarginActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeAddMarginActionCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { Dropdown, DropdownOption } from 'shared/lib/components/common/Dropdown';
+import { DropdownOption } from 'shared/lib/components/common/Dropdown';
 import { GN, GNFormat } from 'shared/lib/data/GoodNumber';
 import { Token } from 'shared/lib/data/Token';
 
@@ -14,8 +14,8 @@ import {
   TokenType,
 } from '../../../data/actions/Actions';
 import { getBalanceFor } from '../../../data/Balances';
-import TokenAmountInput from '../../common/TokenAmountInput';
 import { BaseActionCard } from '../BaseActionCard';
+import TokenAmountSelectInput from '../TokenAmountSelectInput';
 
 export function AloeAddMarginActionCard(prop: ActionCardProps) {
   const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onRemove, onChange } = prop;
@@ -73,24 +73,18 @@ export function AloeAddMarginActionCard(prop: ActionCardProps) {
       isCausingError={isCausingError}
       onRemove={onRemove}
     >
-      <div className='w-full flex flex-col gap-4 items-center'>
-        <Dropdown
-          options={dropdownOptions}
-          selectedOption={selectedTokenOption}
-          onSelect={(option: DropdownOption<TokenType>) => {
-            if (option.value !== selectedTokenOption.value) {
-              callbackWithFullResult(option.value, '');
-            }
-          }}
-        />
-        <TokenAmountInput
-          token={selectedTokenOption.value === TokenType.ASSET0 ? token0 : token1}
-          value={tokenAmount}
-          onChange={(value) => callbackWithFullResult(selectedToken, value)}
-          max={maxString}
-          maxed={tokenAmount === maxString}
-        />
-      </div>
+      <TokenAmountSelectInput
+        inputValue={tokenAmount}
+        options={dropdownOptions}
+        selectedOption={selectedTokenOption}
+        maxAmount={maxString}
+        onChange={(value) => callbackWithFullResult(selectedToken, value)}
+        onSelect={(option: DropdownOption<TokenType>) => {
+          if (option.value !== selectedTokenOption.value) {
+            callbackWithFullResult(option.value, '');
+          }
+        }}
+      />
     </BaseActionCard>
   );
 }

--- a/prime/src/components/borrow/actions/AloeBorrowActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeBorrowActionCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { Dropdown, DropdownOption } from 'shared/lib/components/common/Dropdown';
+import { DropdownOption } from 'shared/lib/components/common/Dropdown';
 import { GN, GNFormat } from 'shared/lib/data/GoodNumber';
 
 import { getBorrowActionArgs } from '../../../data/actions/ActionArgs';
@@ -13,8 +13,8 @@ import {
   TokenType,
 } from '../../../data/actions/Actions';
 import { maxBorrows } from '../../../data/BalanceSheet';
-import TokenAmountInput from '../../common/TokenAmountInput';
 import { BaseActionCard } from '../BaseActionCard';
+import TokenAmountSelectInput from '../TokenAmountSelectInput';
 
 export function AloeBorrowActionCard(prop: ActionCardProps) {
   const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onRemove, onChange } = prop;
@@ -22,14 +22,14 @@ export function AloeBorrowActionCard(prop: ActionCardProps) {
 
   const dropdownOptions: DropdownOption<TokenType>[] = [
     {
-      label: token0?.symbol || '',
+      label: token0.symbol,
       value: TokenType.ASSET0,
-      icon: token0?.logoURI || '',
+      icon: token0.logoURI,
     },
     {
-      label: token1?.symbol || '',
+      label: token1.symbol,
       value: TokenType.ASSET1,
-      icon: token1?.logoURI || '',
+      icon: token1.logoURI,
     },
   ];
   const tokenAmount = userInputFields?.at(1) ?? '';
@@ -89,23 +89,20 @@ export function AloeBorrowActionCard(prop: ActionCardProps) {
       onRemove={onRemove}
     >
       <div className='w-full flex flex-col gap-4 items-center'>
-        <Dropdown
+        <TokenAmountSelectInput
+          inputValue={tokenAmount}
           options={dropdownOptions}
           selectedOption={selectedTokenOption}
+          maxAmount={maxString}
+          maxAmountLabel='Max'
+          maxButtonLabel='80% MAX'
+          onMax={() => callbackWithFullResult(selectedToken, maxEightyPercentString)}
+          onChange={(value) => callbackWithFullResult(selectedToken, value)}
           onSelect={(option: DropdownOption<TokenType>) => {
             if (option.value !== selectedTokenOption.value) {
               callbackWithFullResult(option.value as TokenType, '');
             }
           }}
-        />
-        <TokenAmountInput
-          token={selectedTokenOption.value === TokenType.ASSET0 ? token0 : token1}
-          value={tokenAmount}
-          onChange={(value) => callbackWithFullResult(selectedToken, value)}
-          max={maxString}
-          maxed={tokenAmount === maxEightyPercentString}
-          onMax={() => callbackWithFullResult(selectedToken, maxEightyPercentString)}
-          maxButtonText='80% MAX'
         />
       </div>
     </BaseActionCard>

--- a/prime/src/components/borrow/actions/AloeRepayActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeRepayActionCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { Dropdown, DropdownOption } from 'shared/lib/components/common/Dropdown';
+import { DropdownOption } from 'shared/lib/components/common/Dropdown';
 import { GN, GNFormat } from 'shared/lib/data/GoodNumber';
 
 import { getRepayActionArgs } from '../../../data/actions/ActionArgs';
@@ -12,8 +12,8 @@ import {
   getDropdownOptionFromSelectedToken,
   TokenType,
 } from '../../../data/actions/Actions';
-import TokenAmountInput from '../../common/TokenAmountInput';
 import { BaseActionCard } from '../BaseActionCard';
+import TokenAmountSelectInput from '../TokenAmountSelectInput';
 
 export function AloeRepayActionCard(prop: ActionCardProps) {
   const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onRemove, onChange } = prop;
@@ -74,24 +74,18 @@ export function AloeRepayActionCard(prop: ActionCardProps) {
       isCausingError={isCausingError}
       onRemove={onRemove}
     >
-      <div className='w-full flex flex-col gap-4 items-center'>
-        <Dropdown
-          options={dropdownOptions}
-          selectedOption={selectedTokenOption}
-          onSelect={(option: DropdownOption<TokenType>) => {
-            if (option.value !== selectedTokenOption.value) {
-              callbackWithFullResult(option.value, '');
-            }
-          }}
-        />
-        <TokenAmountInput
-          token={selectedTokenOption.value === TokenType.ASSET0 ? token0 : token1}
-          value={tokenAmount}
-          onChange={(value) => callbackWithFullResult(selectedToken, value)}
-          max={maxString}
-          maxed={tokenAmount === maxString}
-        />
-      </div>
+      <TokenAmountSelectInput
+        inputValue={tokenAmount}
+        options={dropdownOptions}
+        selectedOption={selectedTokenOption}
+        maxAmount={maxString}
+        onChange={(value) => callbackWithFullResult(selectedToken, value)}
+        onSelect={(option: DropdownOption<TokenType>) => {
+          if (option.value !== selectedTokenOption.value) {
+            callbackWithFullResult(option.value, '');
+          }
+        }}
+      />
     </BaseActionCard>
   );
 }

--- a/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { Dropdown, DropdownOption } from 'shared/lib/components/common/Dropdown';
+import { DropdownOption } from 'shared/lib/components/common/Dropdown';
 import { GN, GNFormat } from 'shared/lib/data/GoodNumber';
 import { Token } from 'shared/lib/data/Token';
 
@@ -14,8 +14,8 @@ import {
   TokenType,
 } from '../../../data/actions/Actions';
 import { maxWithdraws } from '../../../data/BalanceSheet';
-import TokenAmountInput from '../../common/TokenAmountInput';
 import { BaseActionCard } from '../BaseActionCard';
+import TokenAmountSelectInput from '../TokenAmountSelectInput';
 
 export function AloeWithdrawActionCard(prop: ActionCardProps) {
   const { marginAccount, accountState, userInputFields, isCausingError, forceOutput, onRemove, onChange } = prop;
@@ -86,26 +86,21 @@ export function AloeWithdrawActionCard(prop: ActionCardProps) {
       isCausingError={isCausingError}
       onRemove={onRemove}
     >
-      <div className='w-full flex flex-col gap-4 items-center'>
-        <Dropdown
-          options={dropdownOptions}
-          selectedOption={selectedTokenOption}
-          onSelect={(option: DropdownOption<TokenType>) => {
-            if (option.value !== selectedTokenOption.value) {
-              callbackWithFullResult(option.value, '');
-            }
-          }}
-        />
-        <TokenAmountInput
-          token={selectedTokenOption.value === TokenType.ASSET0 ? token0 : token1}
-          value={tokenAmount}
-          onChange={(value) => callbackWithFullResult(selectedToken, value)}
-          max={trueMaxString}
-          maxed={tokenAmount === maxString}
-          onMax={() => callbackWithFullResult(selectedToken, maxString)}
-          maxButtonText={hasOutstandingBorrows ? '80% MAX' : undefined}
-        />
-      </div>
+      <TokenAmountSelectInput
+        inputValue={tokenAmount}
+        options={dropdownOptions}
+        selectedOption={selectedTokenOption}
+        maxAmount={trueMaxString}
+        maxAmountLabel='Max'
+        maxButtonLabel={hasOutstandingBorrows ? '80% Max' : 'Max'}
+        onMax={() => callbackWithFullResult(selectedToken, maxString)}
+        onChange={(value) => callbackWithFullResult(selectedToken, value)}
+        onSelect={(option: DropdownOption<TokenType>) => {
+          if (option.value !== selectedTokenOption.value) {
+            callbackWithFullResult(option.value, '');
+          }
+        }}
+      />
     </BaseActionCard>
   );
 }


### PR DESCRIPTION
As the title suggests, I am adding a more compact input for the token amounts on the action cards. This component is similar to the one used in some of the newer portfolio modals on earn, but with slight modifications to work with `TokenType` rather than `Token`.
<img width="416" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/e48a4b45-2f26-4a0a-ab73-1bc6df0a1ef3">
