### PR TITLE
Cleaning up symbol usage since it is no longer optional

### DIFF
--- a/earn/src/components/common/TokenChooser.tsx
+++ b/earn/src/components/common/TokenChooser.tsx
@@ -34,10 +34,10 @@ export default function TokenChooser(props: TokenChooserProps) {
     >
       <RadioButtonsContainer>
         <RadioGroup.Option value={token0.address}>
-          {({ checked }) => <StyledRadioButton checked={checked} label={token0?.symbol || ''} />}
+          {({ checked }) => <StyledRadioButton checked={checked} label={token0.symbol} />}
         </RadioGroup.Option>
         <RadioGroup.Option value={token1.address}>
-          {({ checked }) => <StyledRadioButton checked={checked} label={token1?.symbol || ''} />}
+          {({ checked }) => <StyledRadioButton checked={checked} label={token1.symbol} />}
         </RadioGroup.Option>
       </RadioButtonsContainer>
     </RadioGroup>

--- a/earn/src/components/lend/LendPieChartWidget.tsx
+++ b/earn/src/components/lend/LendPieChartWidget.tsx
@@ -262,7 +262,7 @@ export default function LendPieChartWidget(props: LendPieChartWidgetProps) {
                   <div className='flex flex-col justify-center items-center gap-1'>
                     <Text size='M' weight='bold' color={activeSlice.color}>
                       {formatTokenAmountCompact(activeSlice.tokenBalance.balance)}{' '}
-                      {activeSlice.tokenBalance.token.symbol || ''}
+                      {activeSlice.tokenBalance.token.symbol}
                     </Text>
                     {activeSlice.tokenBalance.isKitty && (
                       <Text size='XS' color='rgba(255, 255, 255, 0.5)'>

--- a/earn/src/components/portfolio/AssetPriceChartWidget.tsx
+++ b/earn/src/components/portfolio/AssetPriceChartWidget.tsx
@@ -62,7 +62,7 @@ export default function AssetPriceChartWidget(props: PortfolioPriceChartWidgetPr
     <div className='flex flex-col justify-between w-full'>
       <div className='flex justify-between items-center my-2 px-3'>
         <Text size='S' weight='bold' color='rgba(130, 160, 182, 1)'>
-          {token?.symbol || ''} Price
+          {token.symbol} Price
         </Text>
         <Display size='M'>{error ? '-' : formatUSD(currentPrice)}</Display>
       </div>

--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -149,7 +149,7 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
   const options: DropdownOption<LendingPair>[] = useMemo(() => {
     return lendingPairs.map((lendingPair) => {
       return {
-        label: `${lendingPair.token0.symbol || ''}/${lendingPair.token1.symbol || ''}`,
+        label: `${lendingPair.token0.symbol}/${lendingPair.token1.symbol}`,
         value: lendingPair,
       };
     });
@@ -239,7 +239,7 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
                 {formatTokenAmount(activeTotalSupply)}
               </Display>
               <Display size='S' className='inline-block ml-0.5'>
-                {activeAsset?.symbol || ''}
+                {activeAsset.symbol}
               </Display>
             </div>
           </LargeCardBodyItem>

--- a/earn/src/components/portfolio/SearchBar.tsx
+++ b/earn/src/components/portfolio/SearchBar.tsx
@@ -68,7 +68,7 @@ export function SearchBar(props: SearchBarProps) {
       .filter((balance) => balance.balance > 0)
       .map((balance) => {
         return {
-          label: balance.token.symbol || '',
+          label: balance.token.symbol,
           value: balance.token,
         };
       });

--- a/earn/src/pages/LendPage.tsx
+++ b/earn/src/pages/LendPage.tsx
@@ -160,7 +160,7 @@ export default function LendPage() {
     const options: MultiDropdownOption<Token>[] = Array.from(uniqueTokens).map((token) => {
       return {
         value: token,
-        label: token.symbol || '',
+        label: token.symbol,
         icon: token.logoURI,
       };
     });

--- a/prime/src/components/borrow/MarginAccountCard.tsx
+++ b/prime/src/components/borrow/MarginAccountCard.tsx
@@ -172,11 +172,11 @@ export function MarginAccountCard(props: MarginAccountCardProps) {
       <CardBodyWrapper>
         <div className='w-full flex flex-row justify-between'>
           <MetricContainer
-            label={token0.symbol ?? 'Token0'}
+            label={token0.symbol}
             value={assets0.sub(liabilities.amount0).toString(GNFormat.LOSSY_HUMAN_SHORT)}
           />
           <MetricContainer
-            label={token1.symbol ?? 'Token1'}
+            label={token1.symbol}
             value={assets1.sub(liabilities.amount1).toString(GNFormat.LOSSY_HUMAN_SHORT)}
           />
           <MetricContainer

--- a/prime/src/components/borrow/TokenAllocationPieChartWidget.tsx
+++ b/prime/src/components/borrow/TokenAllocationPieChartWidget.tsx
@@ -310,7 +310,7 @@ export default function TokenAllocationPieChartWidget(props: TokenAllocationPieC
         <TokenAllocationBreakdown>
           <div className='flex items-center gap-4 w-full'>
             <TokenLabel className={activeIndex !== -1 && activeIndex >= firstHalfOfSlices.length ? 'inactive' : ''}>
-              {token0?.symbol || ''}
+              {token0.symbol}
             </TokenLabel>
             <div className='flex flex-col'>
               {firstHalfOfSlices.map((slice, index) => {
@@ -354,7 +354,7 @@ export default function TokenAllocationPieChartWidget(props: TokenAllocationPieC
           </div>
           <div className='flex items-center gap-4'>
             <TokenLabel className={activeIndex !== -1 && activeIndex < firstHalfOfSlices.length ? 'inactive' : ''}>
-              {token1?.symbol || ''}
+              {token1.symbol}
             </TokenLabel>
             <div className='flex flex-col'>
               {secondHalfOfSlices.map((slice, index) => {

--- a/prime/src/components/borrow/actions/AloeAddMarginActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeAddMarginActionCard.tsx
@@ -23,14 +23,14 @@ export function AloeAddMarginActionCard(prop: ActionCardProps) {
 
   const dropdownOptions: DropdownOption<TokenType>[] = [
     {
-      label: token0?.symbol || '',
+      label: token0.symbol,
       value: TokenType.ASSET0,
-      icon: token0?.logoURI || '',
+      icon: token0.logoURI,
     },
     {
-      label: token1?.symbol || '',
+      label: token1.symbol,
       value: TokenType.ASSET1,
-      icon: token1?.logoURI || '',
+      icon: token1.logoURI,
     },
   ];
   const tokenAmount = userInputFields?.at(1) ?? '';

--- a/prime/src/components/borrow/actions/AloeBorrowActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeBorrowActionCard.tsx
@@ -22,14 +22,14 @@ export function AloeBorrowActionCard(prop: ActionCardProps) {
 
   const dropdownOptions: DropdownOption<TokenType>[] = [
     {
-      label: token0?.symbol || '',
+      label: token0.symbol,
       value: TokenType.ASSET0,
-      icon: token0?.logoURI || '',
+      icon: token0.logoURI,
     },
     {
-      label: token1?.symbol || '',
+      label: token1.symbol,
       value: TokenType.ASSET1,
-      icon: token1?.logoURI || '',
+      icon: token1.logoURI,
     },
   ];
   const tokenAmount = userInputFields?.at(1) ?? '';

--- a/prime/src/components/borrow/actions/AloeRepayActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeRepayActionCard.tsx
@@ -21,14 +21,14 @@ export function AloeRepayActionCard(prop: ActionCardProps) {
 
   const dropdownOptions: DropdownOption<TokenType>[] = [
     {
-      label: token0?.symbol || '',
+      label: token0.symbol,
       value: TokenType.ASSET0,
-      icon: token0?.logoURI || '',
+      icon: token0.logoURI,
     },
     {
-      label: token1?.symbol || '',
+      label: token1.symbol,
       value: TokenType.ASSET1,
-      icon: token1?.logoURI || '',
+      icon: token1.logoURI,
     },
   ];
   const tokenAmount = userInputFields?.at(1) ?? '';

--- a/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
+++ b/prime/src/components/borrow/actions/AloeWithdrawActionCard.tsx
@@ -23,14 +23,14 @@ export function AloeWithdrawActionCard(prop: ActionCardProps) {
 
   const dropdownOptions: DropdownOption<TokenType>[] = [
     {
-      label: token0?.symbol || '',
+      label: token0.symbol,
       value: TokenType.ASSET0,
-      icon: token0?.logoURI || '',
+      icon: token0.logoURI,
     },
     {
-      label: token1?.symbol || '',
+      label: token1.symbol,
       value: TokenType.ASSET1,
-      icon: token1?.logoURI || '',
+      icon: token1.logoURI,
     },
   ];
   const tokenAmount = userInputFields?.at(1) ?? '';

--- a/prime/src/components/common/TokenChooser.tsx
+++ b/prime/src/components/common/TokenChooser.tsx
@@ -34,10 +34,10 @@ export default function TokenChooser(props: TokenChooserProps) {
     >
       <RadioButtonsContainer>
         <RadioGroup.Option value={token0.address}>
-          {({ checked }) => <StyledRadioButton checked={checked} label={token0?.symbol || ''} />}
+          {({ checked }) => <StyledRadioButton checked={checked} label={token0.symbol} />}
         </RadioGroup.Option>
         <RadioGroup.Option value={token1.address}>
-          {({ checked }) => <StyledRadioButton checked={checked} label={token1?.symbol || ''} />}
+          {({ checked }) => <StyledRadioButton checked={checked} label={token1.symbol} />}
         </RadioGroup.Option>
       </RadioButtonsContainer>
     </RadioGroup>

--- a/prime/src/components/graph/tooltips/PnLGraphTooltip.tsx
+++ b/prime/src/components/graph/tooltips/PnLGraphTooltip.tsx
@@ -34,8 +34,8 @@ export default function PnLGraphTooltip(props: {
     const y = data?.payload[0]?.value || 0;
     const x = data?.label || 0;
 
-    const token0Symbol = token0.symbol ?? '';
-    const token1Symbol = token1.symbol ?? '';
+    const token0Symbol = token0.symbol;
+    const token1Symbol = token1.symbol;
     const symbolActive = inTermsOfToken0 ? token0Symbol : token1Symbol;
     const symbolInactive = inTermsOfToken0 ? token1Symbol : token0Symbol;
 


### PR DESCRIPTION
Currently, we have a lot of legacy optional usage of token symbols since they used to be optional. Since it is no longer an optional property, I updated the usage to reflect that.