### PR TITLE
Cleaning up the number formatting for big numbers

### DIFF
--- a/earn/src/components/borrow/UniswapPositionList.tsx
+++ b/earn/src/components/borrow/UniswapPositionList.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { SendTransactionResult } from '@wagmi/core';
 import { FilledGreyButton } from 'shared/lib/components/common/Buttons';
 import { Display, Text } from 'shared/lib/components/common/Typography';
-import { formatTokenAmount, roundPercentage, truncateDecimals } from 'shared/lib/util/Numbers';
+import { formatTokenAmount, roundPercentage } from 'shared/lib/util/Numbers';
 import styled from 'styled-components';
 
 import { sqrtRatioToPrice, sqrtRatioToTick } from '../../data/BalanceSheet';
@@ -178,14 +178,14 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
               <Display size='XS' color={ACCENT_COLOR}>
                 {roundPercentage(amount0Percent, 1)}%
               </Display>
-              <Display size='S'>{truncateDecimals(amount0.toString(), 5)}</Display>
+              <Display size='S'>{formatTokenAmount(amount0, 5)}</Display>
               <Text size='XS'>{marginAccount.token0.symbol}</Text>
             </div>
             <div className='text-right'>
               <Display size='XS' color={ACCENT_COLOR}>
                 {roundPercentage(amount1Percent, 1)}%
               </Display>
-              <Display size='S'>{truncateDecimals(amount1.toString(), 5)}</Display>
+              <Display size='S'>{formatTokenAmount(amount1, 5)}</Display>
               <Text size='XS'>{marginAccount.token1.symbol}</Text>
             </div>
           </div>

--- a/earn/src/components/borrow/modal/WithdrawUniswapNFTModal.tsx
+++ b/earn/src/components/borrow/modal/WithdrawUniswapNFTModal.tsx
@@ -5,7 +5,7 @@ import { ethers } from 'ethers';
 import { FilledStylizedButton } from 'shared/lib/components/common/Buttons';
 import Modal from 'shared/lib/components/common/Modal';
 import { Display, Text } from 'shared/lib/components/common/Typography';
-import { formatTokenAmount, roundPercentage, truncateDecimals } from 'shared/lib/util/Numbers';
+import { formatTokenAmount, roundPercentage } from 'shared/lib/util/Numbers';
 import styled from 'styled-components';
 import { useAccount, useContractWrite, usePrepareContractWrite } from 'wagmi';
 
@@ -222,14 +222,14 @@ export function WithdrawUniswapNFTModal(props: WithdrawUniswapNFTModalProps) {
                   <Display size='XS' color={ACCENT_COLOR}>
                     {roundPercentage(amount0Percent, 1)}%
                   </Display>
-                  <Display size='S'>{truncateDecimals(amount0.toString(), 5)}</Display>
+                  <Display size='S'>{formatTokenAmount(amount0, 5)}</Display>
                   <Text size='XS'>{marginAccount.token0.symbol}</Text>
                 </div>
                 <div className='text-right'>
                   <Display size='XS' color={ACCENT_COLOR}>
                     {roundPercentage(amount1Percent, 1)}%
                   </Display>
-                  <Display size='S'>{truncateDecimals(amount1.toString(), 5)}</Display>
+                  <Display size='S'>{formatTokenAmount(amount1, 5)}</Display>
                   <Text size='XS'>{marginAccount.token1.symbol}</Text>
                 </div>
               </div>

--- a/shared/src/util/Numbers.ts
+++ b/shared/src/util/Numbers.ts
@@ -135,7 +135,9 @@ export function roundUpToNearestN(value: number, n: number): number {
 
 export function formatTokenAmount(amount: number, sigDigs = 4): string {
   //TODO: if we want to support more than one locale, we would need to add more logic here
-  if (amount > 1e6) {
+  if (amount > 1e9) {
+    return amount.toExponential(sigDigs - 3);
+  } else if (amount > 1e6) {
     return amount.toLocaleString('en-US', {
       style: 'decimal',
       notation: 'compact',

--- a/shared/src/util/Numbers.ts
+++ b/shared/src/util/Numbers.ts
@@ -135,7 +135,7 @@ export function roundUpToNearestN(value: number, n: number): number {
 
 export function formatTokenAmount(amount: number, sigDigs = 4): string {
   //TODO: if we want to support more than one locale, we would need to add more logic here
-  if (amount > 1e9) {
+  if (amount > 1e13) {
     return amount.toExponential(sigDigs - 3);
   } else if (amount > 1e6) {
     return amount.toLocaleString('en-US', {


### PR DESCRIPTION
Fixing some bugs with the formatting of certain numbers.
New:
<img width="334" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/1525b71a-9c1f-43c1-9844-06d0ff41bc64">
Old:
<img width="464" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/2b23bf08-7617-43f5-a4c7-b24648b7c46f">
