### PR TITLE
Reworking how we display health

### DIFF
--- a/prime/src/components/borrow/HealthBar.tsx
+++ b/prime/src/components/borrow/HealthBar.tsx
@@ -1,9 +1,11 @@
 import { Display, Text } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
 
+import { getHealthColor } from '../../util/Health';
 import Tooltip from '../common/Tooltip';
 
-const MAX_HEALTH = 3;
+const MAX_HEALTH_BAR = 3;
+const MAX_HEALTH_LABEL = 5;
 const MIN_HEALTH = 0.5;
 
 const HealthBarContainer = styled.div`
@@ -42,8 +44,10 @@ export default function HealthBar(props: HealthBarProps) {
   const { health } = props;
   // Bound health between MIN_HEALTH and MAX_HEALTH
   const healthPercent =
-    ((Math.max(Math.min(health, MAX_HEALTH), MIN_HEALTH) - MIN_HEALTH) / (MAX_HEALTH - MIN_HEALTH)) * 100;
-  const healthLabel = health > MAX_HEALTH ? `${MAX_HEALTH}+` : health.toFixed(2);
+    ((Math.max(Math.min(health, MAX_HEALTH_BAR), MIN_HEALTH) - MIN_HEALTH) / (MAX_HEALTH_BAR - MIN_HEALTH)) * 100;
+  const healthLabel = health > MAX_HEALTH_LABEL ? `${MAX_HEALTH_LABEL}+` : health.toFixed(4);
+  const healthLabelColor = getHealthColor(health);
+
   return (
     <div className='w-full flex flex-col align-middle mb-8 mt-8'>
       <div className='flex gap-2 items-center mb-4'>
@@ -57,7 +61,7 @@ export default function HealthBar(props: HealthBarProps) {
         <Text size='L' weight='medium'>
           Account Health:
         </Text>
-        <Display size='M' weight='medium' className='text-center'>
+        <Display size='M' weight='medium' className='text-center' color={healthLabelColor}>
           {healthLabel}
         </Display>
       </div>

--- a/prime/src/util/Health.ts
+++ b/prime/src/util/Health.ts
@@ -1,9 +1,15 @@
+export const HEALTH_LOW_COLOR = 'rgba(235, 87, 87, 1)';
+export const HEALTH_MEDIUM_COLOR = 'rgba(242, 201, 76, 1)';
+export const HEALTH_HIGH_COLOR = 'rgba(0, 193, 67, 1)';
+export const HEALTH_LOW_THRESHOLD = 1.05;
+export const HEALTH_MEDIUM_THRESHOLD = 1.5;
+
 export function getHealthColor(health: number): string {
-  if (health <= 1.1) {
-    return '#EB5757';
-  } else if (health <= 1.25) {
-    return '#F2C94C';
+  if (health < HEALTH_LOW_THRESHOLD) {
+    return HEALTH_LOW_COLOR;
+  } else if (health < HEALTH_MEDIUM_THRESHOLD) {
+    return HEALTH_MEDIUM_COLOR;
   } else {
-    return '#00C143';
+    return HEALTH_HIGH_COLOR;
   }
 }

--- a/prime/src/util/Health.ts
+++ b/prime/src/util/Health.ts
@@ -2,7 +2,7 @@ export const HEALTH_LOW_COLOR = 'rgba(235, 87, 87, 1)';
 export const HEALTH_MEDIUM_COLOR = 'rgba(242, 201, 76, 1)';
 export const HEALTH_HIGH_COLOR = 'rgba(0, 193, 67, 1)';
 export const HEALTH_LOW_THRESHOLD = 1.05;
-export const HEALTH_MEDIUM_THRESHOLD = 1.5;
+export const HEALTH_MEDIUM_THRESHOLD = 1.4;
 
 export function getHealthColor(health: number): string {
   if (health < HEALTH_LOW_THRESHOLD) {


### PR DESCRIPTION
Making the health displays consistent across prime. Adding more decimal points in the manage account widget health. Adding text coloring to the manage account widget health. One thing to note is that I did update the max health that the manage account widget displays (as "X+") from 3 to 5 (to match the accounts page); however, I did notice that the health bar relies on the health values to be between 0.5 and 3, so technically any value greater than three shows as the max on the health bar, but doesn't show up as "5+" until a value of 5 is reached. If this doesn't make sense, don't worry about it too much. I just feel it is more important to match between pages. I recommend trying it out for yourself and seeing how it feels. We could also just use "3+" everywhere as an alternate option. 

<img width="498" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/5ac9ac4c-0e92-4dea-b529-423744ffb69a">
<img width="498" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/9ad13f61-55b4-4d97-b96b-b63e0b20416f">
<img width="498" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/83ebd574-87ae-484e-9f08-51357efc76b3">
