### PR TITLE
Adding account not found state to prime actions page

### DIFF
--- a/prime/src/components/borrow/AccountNotFound.tsx
+++ b/prime/src/components/borrow/AccountNotFound.tsx
@@ -1,0 +1,33 @@
+import { Text } from 'shared/lib/components/common/Typography';
+import styled from 'styled-components';
+
+import { ReactComponent as AlertIcon } from '../../assets/svg/alert_triangle.svg';
+
+const Container = styled.div`
+  width: 100%;
+  padding: 48px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledAlertIcon = styled(AlertIcon)`
+  path {
+    fill: #ffff;
+    stroke: rgb(6, 11, 15);
+  }
+`;
+
+export default function AccountNotFound() {
+  return (
+    <Container>
+      <StyledAlertIcon width={48} height={48} />
+      <Text size='XL' weight='bold' className='text-center'>
+        Account not found
+      </Text>
+      <Text size='L' weight='medium' className='text-center'>
+        Please check the provided address and your current network.
+      </Text>
+    </Container>
+  );
+}


### PR DESCRIPTION
Currently, we do not properly handle the case where the address provided to the actions page does not match an existing borrower. This leads to a blank page and some errors. To address this, I added a new flow that displays a message when an invalid address is provided (often when someone is not using the correct chain for a given address) and added extra checks to prevent certain errors from occurring. 
<img width="1509" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/fa46476f-ce43-4f59-8e37-c220fb1d25cc">
