### PR TITLE
(Earn) Adding placeholder for the borrow graph

### DIFF
--- a/earn/src/components/borrow/BorrowGraphPlaceholder.tsx
+++ b/earn/src/components/borrow/BorrowGraphPlaceholder.tsx
@@ -4,11 +4,11 @@ import styled from 'styled-components';
 export const BorrowGraphPlaceholder = styled.div`
   height: 374px;
   width: 520px;
-  /* margin-left: auto; */
+  margin-left: auto;
 
   @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     margin-left: 0;
-    /* margin-right: auto; */
+    margin-right: auto;
     /* 99% is important here as the graph does not render properly at 100% width */
     width: 99%;
   }

--- a/earn/src/components/borrow/BorrowGraphPlaceholder.tsx
+++ b/earn/src/components/borrow/BorrowGraphPlaceholder.tsx
@@ -1,0 +1,34 @@
+import { RESPONSIVE_BREAKPOINT_MD } from 'shared/lib/data/constants/Breakpoints';
+import styled from 'styled-components';
+
+export const BorrowGraphPlaceholder = styled.div`
+  height: 374px;
+  width: 520px;
+  /* margin-left: auto; */
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    margin-left: 0;
+    /* margin-right: auto; */
+    /* 99% is important here as the graph does not render properly at 100% width */
+    width: 99%;
+  }
+
+  border-radius: 8px;
+  background-color: #0d171e;
+  background-image: linear-gradient(to right, #0d171e 0%, #131f28 20%, #0d171e 40%, #0d171e 100%);
+  background-repeat: no-repeat;
+  background-size: 200% 100%;
+  display: inline-block;
+  animation: borrowGraphShimmer 0.75s forwards linear infinite;
+  overflow: hidden;
+  position: relative;
+
+  @keyframes borrowGraphShimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: -100% 0;
+    }
+  }
+`;

--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -22,6 +22,7 @@ import MarginAccountLensABI from '../assets/abis/MarginAccountLens.json';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
 import { ReactComponent as InfoIcon } from '../assets/svg/info.svg';
 import BorrowGraph, { BorrowGraphData } from '../components/borrow/BorrowGraph';
+import { BorrowGraphPlaceholder } from '../components/borrow/BorrowGraphPlaceholder';
 import { BorrowMetrics } from '../components/borrow/BorrowMetrics';
 import GlobalStatsTable from '../components/borrow/GlobalStatsTable';
 import ManageAccountButtons from '../components/borrow/ManageAccountButtons';
@@ -567,19 +568,17 @@ export default function BorrowPage() {
             />
           </MonitorContainer>
           <GraphContainer>
-            {graphData && graphData.length > 0 ? (
-              <div>
-                <BorrowGraph graphData={graphData} />
-                <div className='text-center opacity-50 pl-8'>
-                  <Text size='S' weight='regular' color={LABEL_TEXT_COLOR}>
-                    <em>
-                      IV comes from an on-chain oracle. It influences the current collateral factor, which impacts the
-                      health of your account.
-                    </em>
-                  </Text>
-                </div>
+            <div>
+              {graphData && graphData.length > 0 ? <BorrowGraph graphData={graphData} /> : <BorrowGraphPlaceholder />}
+              <div className='text-center opacity-50 pl-8'>
+                <Text size='S' weight='regular' color={LABEL_TEXT_COLOR}>
+                  <em>
+                    IV comes from an on-chain oracle. It influences the current collateral factor, which impacts the
+                    health of your account.
+                  </em>
+                </Text>
               </div>
-            ) : null}
+            </div>
           </GraphContainer>
           <MetricsContainer>
             <BorrowMetrics


### PR DESCRIPTION
Currently, the borrow graph on earn does not show anything while loading and then pops onto the screen when it loads. This can cause some layout shifts. To mitigate this, I added a placeholder for the graph similar to those we used previously.