### PR TITLE
Fixing bug with pagination not reseting page

### DIFF
--- a/shared/src/components/common/Pagination.tsx
+++ b/shared/src/components/common/Pagination.tsx
@@ -135,7 +135,10 @@ export default function Pagination(props: PaginationProps) {
           <Dropdown
             options={itemsPerPageOptions}
             selectedOption={itemsPerPageOption}
-            onSelect={(updatedOption) => onItemsPerPageChange(parseInt(updatedOption.value) as ItemsPerPage)}
+            onSelect={(updatedOption) => {
+              onPageChange(1);
+              onItemsPerPageChange(parseInt(updatedOption.value) as ItemsPerPage);
+            }}
             placeAbove={true}
             small={true}
           />


### PR DESCRIPTION
Currently, there is a bug with pagination that causes the page to crash when the number of items changes to a smaller number while on a page past one. This happens when the combination of the inputs for the number of items per page and the current page results in you being on a page that no longer exists.