### PR TITLE
Adding sorting to the markets page (by apy)

### DIFF
--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -276,3 +276,11 @@ export function filterLendingPairsByTokens(lendingPairs: LendingPair[], tokens: 
     return tokens.some((token) => token.address === pair.token0.address || token.address === pair.token1.address);
   });
 }
+
+export function sortLendingPairsByAPY(lendingPairs: LendingPair[]): LendingPair[] {
+  return lendingPairs.sort((a, b) => {
+    const apyA = a.kitty0Info.apy + a.kitty1Info.apy;
+    const apyB = b.kitty0Info.apy + b.kitty1Info.apy;
+    return apyB - apyA;
+  });
+}

--- a/earn/src/pages/LendPage.tsx
+++ b/earn/src/pages/LendPage.tsx
@@ -30,6 +30,7 @@ import {
   getLendingPairBalances,
   LendingPair,
   LendingPairBalances,
+  sortLendingPairsByAPY,
 } from '../data/LendingPair';
 import { PriceRelayLatestResponse } from '../data/PriceRelayResponse';
 const LEND_TITLE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
@@ -284,10 +285,14 @@ export default function LendPage() {
     );
   }, [lendingPairs, selectedOptions]);
 
-  const filteredPages: LendingPair[][] = useMemo(() => {
+  const sortedLendingPairs = useMemo(() => {
+    return sortLendingPairsByAPY(filteredLendingPairs);
+  }, [filteredLendingPairs]);
+
+  const filteredAndSortedPages: LendingPair[][] = useMemo(() => {
     const pages: LendingPair[][] = [];
     let page: LendingPair[] = [];
-    filteredLendingPairs.forEach((pair, i) => {
+    sortedLendingPairs.forEach((pair, i) => {
       if (i % itemsPerPage === 0 && i !== 0) {
         pages.push(page);
         page = [];
@@ -296,7 +301,7 @@ export default function LendPage() {
     });
     pages.push(page);
     return pages;
-  }, [filteredLendingPairs, itemsPerPage]);
+  }, [sortedLendingPairs, itemsPerPage]);
 
   return (
     <AppPage>
@@ -372,7 +377,7 @@ export default function LendPage() {
             />
           </div>
           <LendCards>
-            {filteredPages[currentPage - 1].map((lendPair, i) => (
+            {filteredAndSortedPages[currentPage - 1].map((lendPair, i) => (
               <LendPairCard
                 key={`${lendPair.token0.address}${lendPair.token1.address}${lendPair.uniswapFeeTier}`}
                 pair={lendPair}


### PR DESCRIPTION
Currently, we do not have any special sorting for the markets page. This PR changes that by sorting the lending cards by apy. The sorting is done by taking the combined average of each lender's apy in the pair.