### PR TITLE
Adding local template functionality

### DIFF
--- a/prime/src/components/borrow/BorrowSelectActionModal.tsx
+++ b/prime/src/components/borrow/BorrowSelectActionModal.tsx
@@ -128,13 +128,9 @@ export default function BorrowSelectActionModal(props: BorrowSelectActionModalPr
       setLocalTemplates(localTemplates);
     };
     updateLocalTemplates();
-    window.addEventListener(TEMPLATE_STORED_EVENT_STRING, () => {
-      updateLocalTemplates();
-    });
+    window.addEventListener(TEMPLATE_STORED_EVENT_STRING, updateLocalTemplates);
     return () => {
-      window.removeEventListener(TEMPLATE_STORED_EVENT_STRING, () => {
-        updateLocalTemplates();
-      });
+      window.removeEventListener(TEMPLATE_STORED_EVENT_STRING, updateLocalTemplates);
     };
   }, []);
 

--- a/prime/src/components/borrow/BorrowSelectActionModal.tsx
+++ b/prime/src/components/borrow/BorrowSelectActionModal.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { SvgWrapper } from 'shared/lib/components/common/SvgWrapper';
 import { Text, Display } from 'shared/lib/components/common/Typography';
 import styled from 'styled-components';
@@ -6,8 +8,9 @@ import tw from 'twin.macro';
 import { ReactComponent as BackArrowIcon } from '../../assets/svg/back_arrow.svg';
 import { ReactComponent as LayersIcon } from '../../assets/svg/layers.svg';
 import { getNameOfAction } from '../../data/actions/ActionID';
-import { ActionProvider, ActionProviders, ActionTemplates } from '../../data/actions/Actions';
+import { ActionProvider, ActionProviders, ActionTemplate, ActionTemplates } from '../../data/actions/Actions';
 import { Action } from '../../data/actions/Actions';
+import { TEMPLATE_STORED_EVENT_STRING, retrieveAllTemplates } from '../../data/actions/StoredActionTemplate';
 import { FullscreenModal } from '../common/Modal';
 
 const SECONDARY_COLOR = 'rgba(130, 160, 182, 1)';
@@ -117,6 +120,27 @@ export type BorrowSelectActionModalProps = {
 
 export default function BorrowSelectActionModal(props: BorrowSelectActionModalProps) {
   const { isOpen, setIsOpen, handleAddAction, handleAddActions } = props;
+  const [localTemplates, setLocalTemplates] = useState<ActionTemplate[]>([]);
+
+  useEffect(() => {
+    const updateLocalTemplates = () => {
+      const localTemplates = retrieveAllTemplates();
+      setLocalTemplates(localTemplates);
+    };
+    updateLocalTemplates();
+    window.addEventListener(TEMPLATE_STORED_EVENT_STRING, () => {
+      updateLocalTemplates();
+    });
+    return () => {
+      window.removeEventListener(TEMPLATE_STORED_EVENT_STRING, () => {
+        updateLocalTemplates();
+      });
+    };
+  }, []);
+
+  const defaultTemplates = Object.values(ActionTemplates);
+  const templates = [...defaultTemplates, ...localTemplates];
+
   return (
     <FullscreenModal open={isOpen} setOpen={setIsOpen}>
       <ActionModalHeader>
@@ -142,8 +166,7 @@ export default function BorrowSelectActionModal(props: BorrowSelectActionModalPr
             </Display>
           </div>
           <ActionButtonsContainer>
-            {Object.entries(ActionTemplates).map((templateData, index) => {
-              const template = templateData[1];
+            {templates.map((template, index) => {
               return (
                 <ActionButton
                   key={index}

--- a/prime/src/components/borrow/ManageAccountWidget.tsx
+++ b/prime/src/components/borrow/ManageAccountWidget.tsx
@@ -29,6 +29,7 @@ import { MarketInfo } from '../../data/MarketInfo';
 import BorrowSelectActionModal from './BorrowSelectActionModal';
 import HealthBar from './HealthBar';
 import { ManageAccountTransactionButton } from './ManageAccountTransactionButton';
+import SaveTemplateButton from './SaveTemplateButton';
 
 const Wrapper = styled.div`
   ${tw`flex flex-col items-center justify-start`}
@@ -425,7 +426,12 @@ export default function ManageAccountWidget(props: ManageAccountWidgetProps) {
             </div>
           </WarningContainer>
         )}
-        <div className='w-full flex justify-end gap-4 mt-4'>
+        <div className='w-full flex justify-between gap-4 mt-4'>
+          <SaveTemplateButton
+            activeActions={activeActions}
+            userInputFields={userInputFields}
+            onAddTemplate={() => {}}
+          />
           <ManageAccountTransactionButton
             userAddress={userAddress}
             accountAddress={accountAddress as Address}

--- a/prime/src/components/borrow/ManageAccountWidget.tsx
+++ b/prime/src/components/borrow/ManageAccountWidget.tsx
@@ -427,11 +427,7 @@ export default function ManageAccountWidget(props: ManageAccountWidgetProps) {
           </WarningContainer>
         )}
         <div className='w-full flex justify-between gap-4 mt-4'>
-          <SaveTemplateButton
-            activeActions={activeActions}
-            userInputFields={userInputFields}
-            onAddTemplate={() => {}}
-          />
+          <SaveTemplateButton activeActions={activeActions} userInputFields={userInputFields} />
           <ManageAccountTransactionButton
             userAddress={userAddress}
             accountAddress={accountAddress as Address}

--- a/prime/src/components/borrow/SaveTemplateButton.tsx
+++ b/prime/src/components/borrow/SaveTemplateButton.tsx
@@ -9,11 +9,10 @@ import SaveTemplateModal from './modal/SaveTemplateModal';
 export type SaveTemplateButtonProps = {
   activeActions: Action[];
   userInputFields: (string[] | undefined)[];
-  onAddTemplate: () => void;
 };
 
 export default function SaveTemplateButton(props: SaveTemplateButtonProps) {
-  const { activeActions, userInputFields, onAddTemplate } = props;
+  const { activeActions, userInputFields } = props;
 
   const [saveModalOpen, setSaveModalOpen] = useState(false);
 
@@ -33,7 +32,6 @@ export default function SaveTemplateButton(props: SaveTemplateButtonProps) {
             userInputFields: userInputFields,
           };
           storeTemplate(template);
-          onAddTemplate();
         }}
       />
     </>

--- a/prime/src/components/borrow/SaveTemplateButton.tsx
+++ b/prime/src/components/borrow/SaveTemplateButton.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import { FilledGreyButton } from 'shared/lib/components/common/Buttons';
+
+import { Action } from '../../data/actions/Actions';
+import { StoredActionTemplate, storeTemplate } from '../../data/actions/StoredActionTemplate';
+import SaveTemplateModal from './modal/SaveTemplateModal';
+
+export type SaveTemplateButtonProps = {
+  activeActions: Action[];
+  userInputFields: (string[] | undefined)[];
+  onAddTemplate: () => void;
+};
+
+export default function SaveTemplateButton(props: SaveTemplateButtonProps) {
+  const { activeActions, userInputFields, onAddTemplate } = props;
+
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+
+  return (
+    <>
+      <FilledGreyButton size='M' onClick={() => setSaveModalOpen(true)} disabled={activeActions.length === 0}>
+        Save Template
+      </FilledGreyButton>
+      <SaveTemplateModal
+        isOpen={saveModalOpen}
+        setIsOpen={setSaveModalOpen}
+        onSave={(templateName: string, templateDescription: string) => {
+          const template: StoredActionTemplate = {
+            name: templateName,
+            description: templateDescription,
+            actionIDs: activeActions.map((action) => action.id),
+            userInputFields: userInputFields,
+          };
+          storeTemplate(template);
+          onAddTemplate();
+        }}
+      />
+    </>
+  );
+}

--- a/prime/src/components/borrow/modal/SaveTemplateModal.tsx
+++ b/prime/src/components/borrow/modal/SaveTemplateModal.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+
+import { FilledGradientButton } from 'shared/lib/components/common/Buttons';
+import { SquareInput } from 'shared/lib/components/common/Input';
+import Modal from 'shared/lib/components/common/Modal';
+import { Text } from 'shared/lib/components/common/Typography';
+import { WARNING } from 'shared/lib/data/constants/Colors';
+
+const MAX_TEMPLATE_NAME_LENGTH = 20;
+const MAX_TEMPLATE_DESCRIPTION_LENGTH = 50;
+
+export type SaveTemplateModalProps = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  onSave: (templateName: string, templateDescription: string) => void;
+};
+
+export default function SaveTemplateModal(props: SaveTemplateModalProps) {
+  const { isOpen, setIsOpen, onSave } = props;
+
+  const [templateName, setTemplateName] = useState('');
+  const [templateDescription, setTemplateDescription] = useState('');
+  const [templateNameIsInvalid, setTemplateNameInvalid] = useState(false);
+  const [templateDescriptionIsInvalid, setTemplateDescriptionInvalid] = useState(false);
+
+  useEffect(() => {
+    setTemplateName('');
+    setTemplateDescription('');
+    setTemplateNameInvalid(false);
+    setTemplateDescriptionInvalid(false);
+  }, [isOpen]);
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} title='Save Template'>
+      <div className='flex flex-col gap-6'>
+        <div className='flex flex-col gap-2'>
+          <Text size='M'>Template Name</Text>
+          <SquareInput
+            size='M'
+            onChange={(e) => {
+              if (e.target.value.length <= MAX_TEMPLATE_NAME_LENGTH) {
+                setTemplateName(e.target.value);
+                setTemplateNameInvalid(false);
+              }
+            }}
+            value={templateName}
+            placeholder='Name'
+            inputClassName={templateNameIsInvalid ? 'outline outline-warning' : ''}
+          />
+          {templateNameIsInvalid && (
+            <Text size='S' color={WARNING}>
+              Template name cannot be empty.
+            </Text>
+          )}
+        </div>
+        <div className='flex flex-col gap-2'>
+          <Text size='M'>Template Description</Text>
+          <SquareInput
+            size='M'
+            onChange={(e) => {
+              if (e.target.value.length <= MAX_TEMPLATE_DESCRIPTION_LENGTH) {
+                setTemplateDescription(e.target.value);
+                setTemplateDescriptionInvalid(false);
+              }
+            }}
+            value={templateDescription}
+            placeholder='Description'
+            inputClassName={templateDescriptionIsInvalid ? 'outline outline-warning' : ''}
+          />
+          {templateDescriptionIsInvalid && (
+            <Text size='S' color={WARNING}>
+              Template description cannot be empty.
+            </Text>
+          )}
+        </div>
+        <FilledGradientButton
+          size='M'
+          className='m-auto'
+          onClick={() => {
+            if (templateName.length === 0 || templateDescription.length === 0) {
+              if (templateName.length === 0) {
+                setTemplateNameInvalid(true);
+              }
+              if (templateDescription.length === 0) {
+                setTemplateDescriptionInvalid(true);
+              }
+              return;
+            }
+            onSave(templateName, templateDescription);
+            setIsOpen(false);
+          }}
+        >
+          Save Template
+        </FilledGradientButton>
+      </div>
+    </Modal>
+  );
+}

--- a/prime/src/data/actions/ActionID.ts
+++ b/prime/src/data/actions/ActionID.ts
@@ -1,3 +1,15 @@
+import {
+  ADD_LIQUIDITY,
+  ADD_MARGIN,
+  Action,
+  BORROW,
+  CLAIM_FEES,
+  REMOVE_LIQUIDITY,
+  REPAY,
+  SWAP,
+  WITHDRAW,
+} from './Actions';
+
 export enum ActionID {
   TRANSFER_IN,
   TRANSFER_OUT,
@@ -51,5 +63,28 @@ export function getNameOfAction(id: ActionID): string {
       return 'Swap';
     default:
       return 'UNKNOWN';
+  }
+}
+
+export function getAction(id: ActionID): Action {
+  switch (id) {
+    case ActionID.TRANSFER_IN:
+      return ADD_MARGIN;
+    case ActionID.TRANSFER_OUT:
+      return WITHDRAW;
+    case ActionID.BORROW:
+      return BORROW;
+    case ActionID.REPAY:
+      return REPAY;
+    case ActionID.ADD_LIQUIDITY:
+      return ADD_LIQUIDITY;
+    case ActionID.REMOVE_LIQUIDITY:
+      return REMOVE_LIQUIDITY;
+    case ActionID.CLAIM_FEES:
+      return CLAIM_FEES;
+    case ActionID.SWAP:
+      return SWAP;
+    default:
+      return ADD_MARGIN;
   }
 }

--- a/prime/src/data/actions/ActionID.ts
+++ b/prime/src/data/actions/ActionID.ts
@@ -1,15 +1,3 @@
-import {
-  ADD_LIQUIDITY,
-  ADD_MARGIN,
-  Action,
-  BORROW,
-  CLAIM_FEES,
-  REMOVE_LIQUIDITY,
-  REPAY,
-  SWAP,
-  WITHDRAW,
-} from './Actions';
-
 export enum ActionID {
   TRANSFER_IN,
   TRANSFER_OUT,
@@ -63,28 +51,5 @@ export function getNameOfAction(id: ActionID): string {
       return 'Swap';
     default:
       return 'UNKNOWN';
-  }
-}
-
-export function getAction(id: ActionID): Action {
-  switch (id) {
-    case ActionID.TRANSFER_IN:
-      return ADD_MARGIN;
-    case ActionID.TRANSFER_OUT:
-      return WITHDRAW;
-    case ActionID.BORROW:
-      return BORROW;
-    case ActionID.REPAY:
-      return REPAY;
-    case ActionID.ADD_LIQUIDITY:
-      return ADD_LIQUIDITY;
-    case ActionID.REMOVE_LIQUIDITY:
-      return REMOVE_LIQUIDITY;
-    case ActionID.CLAIM_FEES:
-      return CLAIM_FEES;
-    case ActionID.SWAP:
-      return SWAP;
-    default:
-      return ADD_MARGIN;
   }
 }

--- a/prime/src/data/actions/Actions.ts
+++ b/prime/src/data/actions/Actions.ts
@@ -95,6 +95,7 @@ export type ActionProvider = {
 export type ActionTemplate = {
   name: string;
   description: string;
+  isLocal: boolean;
   actions: Array<Action>;
   userInputFields?: (string[] | undefined)[];
 };
@@ -186,6 +187,7 @@ export const ActionTemplates: { [key: string]: ActionTemplate } = {
   MARKET_MAKING: {
     name: 'Market-Making',
     description: 'Create an in-range Uniswap Position at 20x leverage.',
+    isLocal: false,
     actions: [ADD_MARGIN, BORROW, BORROW, ADD_LIQUIDITY],
     userInputFields: [[TokenType.ASSET0, '10'], [TokenType.ASSET0, '90'], [TokenType.ASSET1, '0.0625'], undefined],
   },

--- a/prime/src/data/actions/Actions.ts
+++ b/prime/src/data/actions/Actions.ts
@@ -228,3 +228,26 @@ export function calculateHypotheticalStates(
     errorMsg,
   };
 }
+
+export function getAction(id: ActionID): Action {
+  switch (id) {
+    case ActionID.TRANSFER_IN:
+      return ADD_MARGIN;
+    case ActionID.TRANSFER_OUT:
+      return WITHDRAW;
+    case ActionID.BORROW:
+      return BORROW;
+    case ActionID.REPAY:
+      return REPAY;
+    case ActionID.ADD_LIQUIDITY:
+      return ADD_LIQUIDITY;
+    case ActionID.REMOVE_LIQUIDITY:
+      return REMOVE_LIQUIDITY;
+    case ActionID.CLAIM_FEES:
+      return CLAIM_FEES;
+    case ActionID.SWAP:
+      return SWAP;
+    default:
+      return ADD_MARGIN;
+  }
+}

--- a/prime/src/data/actions/StoredActionTemplate.ts
+++ b/prime/src/data/actions/StoredActionTemplate.ts
@@ -1,5 +1,5 @@
-import { ActionID, getAction } from './ActionID';
-import { ActionTemplate } from './Actions';
+import { ActionID } from './ActionID';
+import { ActionTemplate, getAction } from './Actions';
 
 const ACTION_TEMPLATE_PREFIX = 'ACTION_TEMPLATE_';
 

--- a/prime/src/data/actions/StoredActionTemplate.ts
+++ b/prime/src/data/actions/StoredActionTemplate.ts
@@ -1,0 +1,49 @@
+import { ActionID, getAction } from './ActionID';
+import { ActionTemplate } from './Actions';
+
+const ACTION_TEMPLATE_PREFIX = 'ACTION_TEMPLATE_';
+
+export const TEMPLATE_STORED_EVENT_STRING = 'templateStored';
+
+export type StoredActionTemplate = {
+  name: string;
+  description: string;
+  actionIDs: Array<ActionID>;
+  userInputFields?: (string[] | undefined)[];
+};
+
+export function storeTemplate(template: StoredActionTemplate) {
+  localStorage.setItem(`${ACTION_TEMPLATE_PREFIX}${template.name}`, JSON.stringify(template));
+  window.dispatchEvent(new Event(TEMPLATE_STORED_EVENT_STRING));
+}
+
+export function deleteTemplate(name: string) {
+  localStorage.removeItem(`${ACTION_TEMPLATE_PREFIX}${name}`);
+  window.dispatchEvent(new Event(TEMPLATE_STORED_EVENT_STRING));
+}
+
+export function retrieveTemplate(name: string): ActionTemplate | undefined {
+  const template = localStorage.getItem(name);
+  if (template === null) return undefined;
+  const storedTemplate: StoredActionTemplate = JSON.parse(template);
+  return {
+    name: storedTemplate.name,
+    description: storedTemplate.description,
+    isLocal: true,
+    actions: storedTemplate.actionIDs.map((actionID) => getAction(actionID)),
+    userInputFields: storedTemplate.userInputFields,
+  };
+}
+
+export function retrieveAllTemplates(): ActionTemplate[] {
+  const templates: ActionTemplate[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key === null) continue;
+    if (key.startsWith(ACTION_TEMPLATE_PREFIX)) {
+      const template = retrieveTemplate(key);
+      if (template !== undefined) templates.push(template);
+    }
+  }
+  return templates;
+}

--- a/shared/src/data/constants/Colors.ts
+++ b/shared/src/data/constants/Colors.ts
@@ -1,0 +1,1 @@
+export const WARNING = '#EC2D5B';


### PR DESCRIPTION
Adding the ability to create templates and have them saved locally. I have not implemented a way for existing local templates to be deleted (besides editing local storage manually); this will come soon. Most of the styling in this is subject to change and is just an initial design to get things out.

#### No actions (thus no template to save):
<img width="539" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/c41f235f-4d83-434a-bf28-36d2c1bf358a">

#### Actions:
<img width="539" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/40593387-8517-49c3-87d0-c868dd5b7a04">

#### Save template modal:
<img width="539" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/f603815d-3fb3-4265-9a6e-4ff4260c1011">

#### Save template modal validation:
<img width="539" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/e48f803c-fbdd-4be8-b564-14bc35456dad">

#### Local template:
<img width="920" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/417277f6-d637-4c7e-ad66-e8c65e70e5aa">


