### PR TITLE
Clearing portfolio page on disconnect

### DIFF
--- a/earn/src/pages/PortfolioPage.tsx
+++ b/earn/src/pages/PortfolioPage.tsx
@@ -258,6 +258,13 @@ export default function PortfolioPage() {
     };
   }, [pendingTxn]);
 
+  useEffect(() => {
+    if (!isConnected && !isConnecting && lendingPairBalances.length > 0) {
+      setLendingPairBalances([]);
+      setActiveAsset(null);
+    }
+  }, [isConnecting, isConnected, lendingPairBalances]);
+
   const combinedBalances: TokenBalance[] = useMemo(() => {
     const combined = lendingPairs.flatMap((pair, i) => {
       const token0Quote = tokenQuotes.find((quote) => quote.token.address === pair.token0.address);


### PR DESCRIPTION
Adding logic to clear the portfolio page when the user disconnects their wallet. This prevents the page from looking like the user is still connected when they are not.