### PR TITLE
Only show modals when connected

### DIFF
--- a/earn/src/pages/BorrowPage.tsx
+++ b/earn/src/pages/BorrowPage.tsx
@@ -181,7 +181,7 @@ export type UniswapPoolInfo = {
 export default function BorrowPage() {
   const { activeChain } = useContext(ChainContext);
   const provider = useProvider({ chainId: activeChain.id });
-  const { address: userAddress } = useAccount();
+  const { address: userAddress, isConnected } = useAccount();
 
   const [availablePools, setAvailablePools] = useState(new Map<string, UniswapPoolInfo>());
   const [cachedGraphDatas, setCachedGraphDatas] = useState<Map<string, BorrowGraphData[]>>(new Map());
@@ -510,6 +510,7 @@ export default function BorrowPage() {
 
   const baseEtherscanUrl = getEtherscanUrlForChain(activeChain);
   const selectedMarginAccountEtherscanUrl = `${baseEtherscanUrl}/address/${selectedMarginAccount?.address}`;
+
   return (
     <AppPage>
       <Container>
@@ -548,16 +549,16 @@ export default function BorrowPage() {
             </Text>
             <ManageAccountButtons
               onAddCollateral={() => {
-                setIsAddCollateralModalOpen(true);
+                if (isConnected) setIsAddCollateralModalOpen(true);
               }}
               onRemoveCollateral={() => {
-                setIsRemoveCollateralModalOpen(true);
+                if (isConnected) setIsRemoveCollateralModalOpen(true);
               }}
               onBorrow={() => {
-                setIsBorrowModalOpen(true);
+                if (isConnected) setIsBorrowModalOpen(true);
               }}
               onRepay={() => {
-                setIsRepayModalOpen(true);
+                if (isConnected) setIsRepayModalOpen(true);
               }}
               onGetLeverage={() => {
                 if (selectedMarginAccount != null) {

--- a/earn/src/pages/PortfolioPage.tsx
+++ b/earn/src/pages/PortfolioPage.tsx
@@ -399,21 +399,31 @@ export default function PortfolioPage() {
           <PortfolioActionButton
             label={'Send Crypto'}
             Icon={<SendIcon />}
-            onClick={() => setIsSendCryptoModalOpen(true)}
+            onClick={() => {
+              if (isConnected) setIsSendCryptoModalOpen(true);
+            }}
           />
           <PortfolioActionButton
             label={'Deposit'}
             Icon={<TrendingUpIcon />}
-            onClick={() => setIsEarnInterestModalOpen(true)}
+            onClick={() => {
+              if (isConnected) setIsEarnInterestModalOpen(true);
+            }}
           />
           <PortfolioActionButton
             label={'Withdraw'}
             Icon={<ShareIcon />}
             onClick={() => {
-              setIsWithdrawModalOpen(true);
+              if (isConnected) setIsWithdrawModalOpen(true);
             }}
           />
-          <PortfolioActionButton label={'Bridge'} Icon={<TruckIcon />} onClick={() => setIsBridgeModalOpen(true)} />
+          <PortfolioActionButton
+            label={'Bridge'}
+            Icon={<TruckIcon />}
+            onClick={() => {
+              if (isConnected) setIsBridgeModalOpen(true);
+            }}
+          />
         </PortfolioActionButtonsContainer>
         <div className='mt-10'>
           <PortfolioPageWidgetWrapper tooltip={PORTFOLIO_GRID_TOOLTIP_TEXT} tooltipId='portfolioGrid'>


### PR DESCRIPTION
Instead of potentially stacking up a bunch of open modals while disconnected, limit the opening of modals to connected accounts.