### PR TITLE
Only fetch price relay data when tokens are for correct chain

### DIFF
--- a/earn/src/pages/PortfolioPage.tsx
+++ b/earn/src/pages/PortfolioPage.tsx
@@ -142,6 +142,10 @@ export default function PortfolioPage() {
   useEffect(() => {
     let mounted = true;
     async function fetch() {
+      // Only fetch prices for tokens if they are all on the same (active) chain
+      if (uniqueTokens.length > 0 && uniqueTokens.some((token) => token.chainId !== activeChain.id)) {
+        return;
+      }
       const symbols = uniqueTokens
         .map((token) => token?.symbol)
         .filter((symbol) => symbol !== undefined)


### PR DESCRIPTION
Currently, there is a bug that causes us to try to get tokens for the previous chain when switching chains. The logic added in this PR prevents this from happening.