### PR TITLE
Remove link to Prime from header

### DIFF
--- a/earn/src/components/header/Header.tsx
+++ b/earn/src/components/header/Header.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 
 import { ChainContext } from '../../App';
-import { primeUrl } from '../../data/constants/Values';
 
 const NAV_LINKS: NavBarLink[] = [
   {
@@ -18,13 +17,8 @@ const NAV_LINKS: NavBarLink[] = [
     to: '/markets',
   },
   {
-    label: 'Borrow',
-    to: '/borrow',
-  },
-  {
     label: 'Advanced',
-    to: primeUrl(),
-    isExternal: true,
+    to: '/borrow',
   },
 ];
 


### PR DESCRIPTION
Users can access Prime by clicking "Get Leverage" from the borrower page. Renamed "Borrow" tab to "Advanced" since the markets page will soon offer basic borrowing functionality.