### PR TITLE
Improving uniswap hypotheticals

### DIFF
--- a/prime/src/components/borrow/uniswap/UniswapPositionsTable.tsx
+++ b/prime/src/components/borrow/uniswap/UniswapPositionsTable.tsx
@@ -243,11 +243,10 @@ export default function UniswapPositionTable(props: UniswapPositionsTableProps) 
 
   let rows: Array<JSX.Element[]> = [];
   for (const item of uniswapPositionInfo) {
-    // TODO: sometimes we have issues with undefined values here, investigate
-    const fees = uniswapPositionEarnedFees[item.positionKey];
-    if (!fees) {
-      continue;
-    }
+    const fees = uniswapPositionEarnedFees[item.positionKey] || {
+      token0FeesEarned: GN.zero(marginAccount.token0.decimals),
+      token1FeesEarned: GN.zero(marginAccount.token1.decimals),
+    };
     const selectedTokenSymbol = selectedToken.symbol;
     const value = isInTermsOfToken0
       ? item.value.setResolution(marginAccount.token0.decimals).div(item.current)

--- a/prime/src/components/borrow/uniswap/UniswapPositionsTable.tsx
+++ b/prime/src/components/borrow/uniswap/UniswapPositionsTable.tsx
@@ -243,7 +243,7 @@ export default function UniswapPositionTable(props: UniswapPositionsTableProps) 
 
   let rows: Array<JSX.Element[]> = [];
   for (const item of uniswapPositionInfo) {
-    const fees = uniswapPositionEarnedFees[item.positionKey] || {
+    const fees = uniswapPositionEarnedFees[item.positionKey] ?? {
       token0FeesEarned: GN.zero(marginAccount.token0.decimals),
       token1FeesEarned: GN.zero(marginAccount.token1.decimals),
     };


### PR DESCRIPTION
Currently, the uniswap positions table on prime does not work well with hypotheticals. I updated the underlying logic to not ignore new uniswap positions (those without fee data).