### PR TITLE
Adding liquidity chart

### DIFF
--- a/earn/src/App.tsx
+++ b/earn/src/App.tsx
@@ -50,6 +50,21 @@ export const theGraphUniswapV3Client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
+export const theGraphUniswapV3ArbitrumClient = new ApolloClient({
+  link: new HttpLink({ uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-minimal' }),
+  cache: new InMemoryCache(),
+});
+
+export const theGraphUniswapV3OptimismClient = new ApolloClient({
+  link: new HttpLink({ uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/optimism-post-regenesis' }),
+  cache: new InMemoryCache(),
+});
+
+export const theGraphUniswapV3GoerliClient = new ApolloClient({
+  link: new HttpLink({ uri: 'https://api.thegraph.com/subgraphs/name/0xfind/uniswap-v3-goerli-2' }),
+  cache: new InMemoryCache(),
+});
+
 export const theGraphEthereumBlocksClient = new ApolloClient({
   link: new HttpLink({ uri: 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks' }),
   cache: new InMemoryCache(),

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -68,7 +68,7 @@ export default function LiquidityChart(props: LiquidityChartProps) {
     const updatedChartData = liquidityDataCopy.map((td: TickData) => {
       return { price: td.price0In1, liquidityDensity: td.totalValueIn0 };
     });
-    // TODO: use a better filter
+    // TODO: temporary filter while we still use the graph (their data isn't great)
     const filteredChartData = updatedChartData.filter((d) => d.liquidityDensity > 0);
     setChartData(filteredChartData);
   }, [liquidityData, maxPrice, minPrice]);

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -69,9 +69,7 @@ export default function LiquidityChart(props: LiquidityChartProps) {
       return { price: td.price0In1, liquidityDensity: td.totalValueIn0 };
     });
     // TODO: use a better filter
-    const filteredChartData = updatedChartData.filter(
-      (d) => d.liquidityDensity > 0 && d.price > minPrice - 200 && d.price < maxPrice + 300
-    );
+    const filteredChartData = updatedChartData.filter((d) => d.liquidityDensity > 0);
     setChartData(filteredChartData);
   }, [liquidityData, maxPrice, minPrice]);
 

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -1,0 +1,135 @@
+import { useContext, useEffect, useState } from 'react';
+
+import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
+import useEffectOnce from 'shared/lib/data/hooks/UseEffectOnce';
+import styled from 'styled-components';
+import { useProvider } from 'wagmi';
+
+import { ChainContext } from '../../App';
+import { TickData, calculateTickData, fetchUniswapPoolBasics } from '../../data/Uniswap';
+import LiquidityChartTooltip from './LiquidityChartTooltip';
+
+export type ChartEntry = {
+  price: number;
+  liquidityDensity: number;
+};
+
+const Wrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 200px;
+  margin-bottom: -20px;
+`;
+
+const ChartWrapper = styled.div`
+  position: absolute;
+  width: 300px;
+  height: 200px;
+  top: 0;
+  left: -16px;
+`;
+
+export type LiquidityChartProps = {
+  poolAddress: string;
+  currentPrice: number;
+  minPrice: number;
+  maxPrice: number;
+};
+
+export default function LiquidityChart(props: LiquidityChartProps) {
+  const { poolAddress, currentPrice, minPrice, maxPrice } = props;
+  const { activeChain } = useContext(ChainContext);
+  const provider = useProvider();
+  const [liquidityData, setLiquidityData] = useState<TickData[] | null>(null);
+  const [chartData, setChartData] = useState<{ price: number; liquidityDensity: number }[] | null>(null);
+
+  // Fetch (a) uniswapPoolBasics from ethers and (b) liquidityData from TheGraph
+  useEffectOnce(() => {
+    let mounted = true;
+    async function fetch(poolAddress: string) {
+      const poolBasics = await fetchUniswapPoolBasics(poolAddress, provider);
+      const tickData = await calculateTickData(poolAddress, poolBasics, activeChain.id);
+      if (mounted) {
+        setLiquidityData(tickData);
+      }
+    }
+    fetch(poolAddress);
+    return () => {
+      mounted = false;
+    };
+  });
+
+  // Once liquidityData has been fetched, arrange/format it to be workable chartData
+  useEffect(() => {
+    if (liquidityData == null) return;
+
+    const liquidityDataCopy = liquidityData.concat();
+
+    const updatedChartData = liquidityDataCopy.map((td: TickData) => {
+      return { price: td.price0In1, liquidityDensity: td.totalValueIn0 };
+    });
+    // TODO: use a better filter
+    const filteredChartData = updatedChartData.filter(
+      (d) => d.liquidityDensity > 0 && d.price > minPrice - 200 && d.price < maxPrice + 300
+    );
+    setChartData(filteredChartData);
+  }, [liquidityData, maxPrice, minPrice]);
+
+  if (chartData == null || chartData.length < 3) return null;
+  const lowestPrice = chartData[0].price;
+  const highestPrice = chartData[chartData.length - 1].price;
+  return (
+    <Wrapper>
+      <ChartWrapper>
+        <ResponsiveContainer width='100%' height='100%'>
+          <div>
+            <AreaChart
+              data={chartData}
+              width={300}
+              height={200}
+              margin={{
+                top: 0,
+                right: 0,
+                left: 0,
+                bottom: 0,
+              }}
+            >
+              <Area
+                type={'monotone'}
+                dataKey={'liquidityDensity'}
+                data={chartData.filter((d) => d.price >= minPrice && d.price <= currentPrice)}
+                stroke={'grey'}
+                fill={'grey'}
+                fillOpacity={0.5}
+                activeDot={false}
+              />
+              <Area
+                type={'monotone'}
+                dataKey={'liquidityDensity'}
+                data={chartData.filter((d) => d.price >= currentPrice)}
+                stroke={'magenta'}
+                fill={'magenta'}
+                fillOpacity={0.5}
+                activeDot={false}
+              />
+              <Tooltip
+                isAnimationActive={false}
+                content={(props: any) => {
+                  return (
+                    <LiquidityChartTooltip
+                      active={props?.active ?? false}
+                      selectedPrice={props?.payload[0]?.payload.price}
+                      currentPrice={currentPrice}
+                      x={props?.coordinate?.x ?? 0}
+                    />
+                  );
+                }}
+              />
+              <XAxis dataKey='price' type='number' domain={[lowestPrice, highestPrice]} tick={false} height={0} />
+            </AreaChart>
+          </div>
+        </ResponsiveContainer>
+      </ChartWrapper>
+    </Wrapper>
+  );
+}

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -27,6 +27,9 @@ const ChartWrapper = styled.div`
   height: 200px;
   top: 0;
   left: -16px;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  overflow: hidden;
 `;
 
 export type LiquidityChartProps = {

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { Text } from 'shared/lib/components/common/Typography';
+import { GREY_700 } from 'shared/lib/data/constants/Colors';
+import { roundPercentage } from 'shared/lib/util/Numbers';
+import styled from 'styled-components';
+import tw from 'twin.macro';
+
+export const PERCENTAGE_WIDTH = 75;
+const TOOLTIP_BG_COLOR = 'rgba(13, 23, 30, 1)';
+const TOOLTIP_BORDER_COLOR = GREY_700;
+
+const TooltipContainer = styled.div.attrs((props: { offset: number }) => props)`
+  ${tw`rounded-md shadow-md`}
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(clamp(0px, ${(props) => props.offset - PERCENTAGE_WIDTH / 2}px, 225px));
+  border: 1px solid ${TOOLTIP_BORDER_COLOR};
+  width: ${PERCENTAGE_WIDTH}px;
+  box-shadow: 0px 8px 32px 0px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(24px);
+  background: ${TOOLTIP_BG_COLOR};
+  visibility: visible;
+`;
+
+export default function LiquidityChartTooltip(props: {
+  active: boolean;
+  selectedPrice: number;
+  currentPrice: number;
+  x: number;
+}) {
+  const { active, selectedPrice, currentPrice, x } = props;
+  if (active) {
+    const percentChange = ((selectedPrice - currentPrice) / currentPrice) * 100 || 0;
+    return (
+      <TooltipContainer offset={x}>
+        <div className='flex flex-col justify-between gap-2 mt-4 pl-3 pr-3 pb-3'>
+          <div className='flex flex-col justify-center items-center'>
+            <Text size='M' weight='bold'>
+              {roundPercentage(percentChange, 1)}%
+            </Text>
+          </div>
+        </div>
+      </TooltipContainer>
+    );
+  }
+  return null;
+}

--- a/earn/src/pages/BoostPage.tsx
+++ b/earn/src/pages/BoostPage.tsx
@@ -9,6 +9,7 @@ import { formatTokenAmount, roundPercentage, toBig } from 'shared/lib/util/Numbe
 import { useAccount, useContractReads, useProvider } from 'wagmi';
 
 import { ChainContext } from '../App';
+import LiquidityChart from '../components/boost/LiquidityChart';
 import TokenPairIcons from '../components/common/TokenPairIcons';
 import {
   InRangeBadge,
@@ -105,6 +106,9 @@ export default function BoostPage() {
 
       const isDeposit = Math.random() > 0.5; // TODO: figure out how to determine if this is a deposit or withdrawal
 
+      const poolAddress = computePoolAddress(position);
+      const currentPrice = sqrtRatioToPrice(toBig(sqrtPriceX96), token0.decimals, token1.decimals);
+
       return {
         token0: token0,
         token1: token1,
@@ -116,6 +120,8 @@ export default function BoostPage() {
         amount1Percent: amount1Percent,
         isInRange: isInRange,
         isDeposit: isDeposit,
+        poolAddress: poolAddress,
+        currentPrice: currentPrice,
       };
     });
   }, [nonZeroUniswapNFTPositions, slot0Data]);
@@ -199,6 +205,12 @@ export default function BoostPage() {
                     )}
                   </div>
                 </div>
+                <LiquidityChart
+                  poolAddress={position.poolAddress}
+                  minPrice={position.minPrice}
+                  maxPrice={position.maxPrice}
+                  currentPrice={position.currentPrice}
+                />
               </UniswapPositionCardWrapper>
             </UniswapPositionCardContainer>
           );


### PR DESCRIPTION
Adding a liquidity chart to the boost cards.
<img width="318" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/b0cf5241-66ef-4570-879e-ff87557aae32">
