### PR TITLE
Fetch all ticks for liquidity chart

### DIFF
--- a/earn/src/components/boost/BoostCard.tsx
+++ b/earn/src/components/boost/BoostCard.tsx
@@ -19,7 +19,9 @@ export type UniswapPositionCardProps = {
   token1: Token;
   minPrice: number;
   maxPrice: number;
-  currentPrice: number;
+  minTick: number;
+  maxTick: number;
+  currentTick: number;
   amount0: number;
   amount1: number;
   amount0Percent: number;
@@ -38,7 +40,9 @@ export default function BoostCard(props: UniswapPositionCardProps) {
     token1,
     minPrice,
     maxPrice,
-    currentPrice,
+    minTick,
+    maxTick,
+    currentTick,
     amount0,
     amount1,
     amount0Percent,
@@ -113,9 +117,9 @@ export default function BoostCard(props: UniswapPositionCardProps) {
         </div>
         <LiquidityChart
           poolAddress={poolAddress}
-          minPrice={minPrice}
-          maxPrice={maxPrice}
-          currentPrice={currentPrice}
+          minTick={minTick}
+          maxTick={maxTick}
+          currentTick={currentTick}
           color0={color0}
           color1={color1}
           uniqueId={uniqueId}

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -118,8 +118,8 @@ export default function LiquidityChart(props: LiquidityChartProps) {
     positionHighlight = (
       <linearGradient id={positionHighlightId} x1='0' y1='0' x2='1' y2='0'>
         <stop offset={lower} stopColor='white' stopOpacity={0.0} />
-        <stop offset={lower} stopColor={color1} stopOpacity={0.5} />
-        <stop offset={upper} stopColor={color1} stopOpacity={0.5} />
+        <stop offset={lower} stopColor={color0} stopOpacity={0.5} />
+        <stop offset={upper} stopColor={color0} stopOpacity={0.5} />
         <stop offset={upper} stopColor='white' stopOpacity={0.0} />
       </linearGradient>
     );
@@ -127,10 +127,10 @@ export default function LiquidityChart(props: LiquidityChartProps) {
     positionHighlight = (
       <linearGradient id={positionHighlightId} x1='0' y1='0' x2='1' y2='0'>
         <stop offset={lower} stopColor='white' stopOpacity={0.0} />
-        <stop offset={lower} stopColor={color0} stopOpacity={0.5} />
-        <stop offset={current} stopColor={color0} stopOpacity={0.5} />
+        <stop offset={lower} stopColor={color1} stopOpacity={0.5} />
         <stop offset={current} stopColor={color1} stopOpacity={0.5} />
-        <stop offset={upper} stopColor={color1} stopOpacity={0.5} />
+        <stop offset={current} stopColor={color0} stopOpacity={0.5} />
+        <stop offset={upper} stopColor={color0} stopOpacity={0.5} />
         <stop offset={upper} stopColor='white' stopOpacity={0} />
       </linearGradient>
     );
@@ -138,8 +138,8 @@ export default function LiquidityChart(props: LiquidityChartProps) {
     positionHighlight = (
       <linearGradient id={positionHighlightId} x1='0' y1='0' x2='1' y2='0'>
         <stop offset={lower} stopColor='white' stopOpacity={0.0} />
-        <stop offset={lower} stopColor={color0} stopOpacity={0.5} />
-        <stop offset={upper} stopColor={color0} stopOpacity={0.5} />
+        <stop offset={lower} stopColor={color1} stopOpacity={0.5} />
+        <stop offset={upper} stopColor={color1} stopOpacity={0.5} />
         <stop offset={upper} stopColor='white' stopOpacity={0.0} />
       </linearGradient>
     );
@@ -164,8 +164,8 @@ export default function LiquidityChart(props: LiquidityChartProps) {
               <defs>
                 {positionHighlight}
                 <linearGradient id={'currentPriceSplit'.concat(uniqueId)} x1='0' y1='0' x2='1' y2='0'>
-                  <stop offset={current} stopColor={color0} stopOpacity={1} />
                   <stop offset={current} stopColor={color1} stopOpacity={1} />
+                  <stop offset={current} stopColor={color0} stopOpacity={1} />
                 </linearGradient>
                 <pattern
                   id='stripes'

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -200,7 +200,7 @@ export default function LiquidityChart(props: LiquidityChartProps) {
                 }}
               />
               <Area
-                type='step'
+                type='stepAfter'
                 dataKey='liquidityDensity'
                 stroke={'url(#currentPriceSplit'.concat(uniqueId, ')')}
                 strokeWidth='3'

--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -10,8 +10,8 @@ import { TickData, calculateTickData, fetchUniswapPoolBasics } from '../../data/
 import { LiquidityChartPlaceholder } from './LiquidityChartPlaceholder';
 import LiquidityChartTooltip from './LiquidityChartTooltip';
 
-export type ChartEntry = {
-  price: number;
+type ChartEntry = {
+  tick: number;
   liquidityDensity: number;
 };
 
@@ -37,20 +37,20 @@ const ChartWrapper = styled.div`
 
 export type LiquidityChartProps = {
   poolAddress: string;
-  currentPrice: number;
-  minPrice: number;
-  maxPrice: number;
+  currentTick: number;
+  minTick: number;
+  maxTick: number;
   color0: string;
   color1: string;
   uniqueId: string;
 };
 
 export default function LiquidityChart(props: LiquidityChartProps) {
-  const { poolAddress, currentPrice, minPrice, maxPrice, color0, color1, uniqueId } = props;
+  const { poolAddress, currentTick, minTick, maxTick, color0, color1, uniqueId } = props;
   const { activeChain } = useContext(ChainContext);
   const provider = useProvider();
   const [liquidityData, setLiquidityData] = useState<TickData[] | null>(null);
-  const [chartData, setChartData] = useState<{ price: number; liquidityDensity: number }[] | null>(null);
+  const [chartData, setChartData] = useState<ChartEntry[] | null>(null);
 
   // Fetch (a) uniswapPoolBasics from ethers and (b) liquidityData from TheGraph
   useEffectOnce(() => {
@@ -71,48 +71,50 @@ export default function LiquidityChart(props: LiquidityChartProps) {
   // Once liquidityData has been fetched, arrange/format it to be workable chartData
   useEffect(() => {
     if (liquidityData == null) return;
-    let cutoffLeft = Math.min(minPrice, currentPrice);
-    let cutoffRight = Math.max(maxPrice, currentPrice);
-    let zoom = (cutoffRight - cutoffLeft) / ((cutoffRight + cutoffLeft) / 2);
-    zoom = Math.max(1.01, Math.min(zoom, 1.15));
-    cutoffLeft /= zoom;
-    cutoffRight *= zoom;
 
-    const chartData: { price: number; liquidityDensity: number }[] = [];
+    // Make sure graph shows position bounds (both lower and upper) and the current tick
+    let cutoffLeft = Math.min(minTick, currentTick);
+    let cutoffRight = Math.max(maxTick, currentTick);
+    // Zoom out a bit to make things prettier
+    const positionWidth = maxTick - minTick;
+    cutoffLeft -= positionWidth;
+    cutoffRight += positionWidth;
+
+    const newChartData: ChartEntry[] = [];
     let minValue = Number.MAX_VALUE;
     let maxValue = 0;
 
     for (const element of liquidityData) {
-      const price = element.price0In1;
-      let liquidityDensity = element.totalValueIn0;
+      const tick = element.tick;
+      let liquidityDensity = element.liquidity.toNumber();
 
       if (liquidityDensity <= 0) continue;
-      if (price < cutoffLeft || price > cutoffRight) continue;
+      if (tick < cutoffLeft || tick > cutoffRight) continue;
 
-      liquidityDensity = Math.log10(liquidityDensity);
       minValue = Math.min(minValue, liquidityDensity);
       maxValue = Math.max(maxValue, liquidityDensity);
 
-      chartData.push({ price, liquidityDensity });
+      newChartData.push({ tick, liquidityDensity });
     }
 
-    chartData.forEach((el) => (el.liquidityDensity = el.liquidityDensity - minValue));
-    setChartData(chartData);
-  }, [liquidityData, minPrice, maxPrice, currentPrice]);
+    const range = maxValue - minValue;
+    newChartData.forEach((el) => (el.liquidityDensity = el.liquidityDensity - minValue + range / 8));
+    setChartData(newChartData);
+  }, [liquidityData, minTick, maxTick, currentTick]);
 
   if (chartData == null || chartData.length < 3) return <LiquidityChartPlaceholder />;
 
-  const lowestPrice = chartData[0].price;
-  const highestPrice = chartData[chartData.length - 1].price;
+  const lowestTick = chartData[0].tick;
+  const highestTick = chartData[chartData.length - 1].tick;
 
-  const width = highestPrice - lowestPrice;
-  const lower = (minPrice - lowestPrice) / width;
-  const upper = (maxPrice - lowestPrice) / width;
-  const current = (currentPrice - lowestPrice) / width;
+  const domain = highestTick - lowestTick;
+  const lower = (minTick - lowestTick) / domain;
+  const upper = (maxTick - lowestTick) / domain;
+  const current = (currentTick - lowestTick) / domain;
 
   let positionHighlight: JSX.Element;
   const positionHighlightId = 'positionHighlight'.concat(uniqueId);
-  if (currentPrice < minPrice) {
+  if (currentTick < minTick) {
     positionHighlight = (
       <linearGradient id={positionHighlightId} x1='0' y1='0' x2='1' y2='0'>
         <stop offset={lower} stopColor='white' stopOpacity={0.0} />
@@ -121,7 +123,7 @@ export default function LiquidityChart(props: LiquidityChartProps) {
         <stop offset={upper} stopColor='white' stopOpacity={0.0} />
       </linearGradient>
     );
-  } else if (currentPrice < maxPrice) {
+  } else if (currentTick < maxTick) {
     positionHighlight = (
       <linearGradient id={positionHighlightId} x1='0' y1='0' x2='1' y2='0'>
         <stop offset={lower} stopColor='white' stopOpacity={0.0} />
@@ -188,10 +190,17 @@ export default function LiquidityChart(props: LiquidityChartProps) {
                   />
                 </pattern>
               </defs>
-              <XAxis dataKey='price' type='number' domain={[lowestPrice, highestPrice]} tick={false} height={0} />
-              <YAxis hide={true} type='number' domain={['dataMin', (dataMax: number) => dataMax * 1.25]} />
+              <XAxis dataKey='tick' type='number' domain={[lowestTick, highestTick]} tick={false} height={0} />
+              <YAxis
+                hide={true}
+                type='number'
+                domain={([dataMin, dataMax]: [number, number]) => {
+                  const range = dataMax - dataMin;
+                  return [dataMin - range / 8, dataMax + range / 4];
+                }}
+              />
               <Area
-                type='natural'
+                type='step'
                 dataKey='liquidityDensity'
                 stroke={'url(#currentPriceSplit'.concat(uniqueId, ')')}
                 strokeWidth='3'
@@ -204,15 +213,15 @@ export default function LiquidityChart(props: LiquidityChartProps) {
                 }}
                 isAnimationActive={false}
               />
-              <ReferenceLine x={currentPrice} stroke='white' strokeWidth='1' />
+              <ReferenceLine x={currentTick} stroke='white' strokeWidth='1' />
               <Tooltip
                 isAnimationActive={false}
                 content={(props: any) => {
                   return (
                     <LiquidityChartTooltip
                       active={props?.active ?? false}
-                      selectedPrice={props?.payload[0]?.payload.price}
-                      currentPrice={currentPrice}
+                      selectedTick={props?.payload[0]?.payload.tick}
+                      currentTick={currentTick}
                       x={props?.coordinate?.x ?? 0}
                       chartWidth={CHART_WIDTH}
                     />

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Text } from 'shared/lib/components/common/Typography';
 import { GREY_700 } from 'shared/lib/data/constants/Colors';
 import { roundPercentage } from 'shared/lib/util/Numbers';
@@ -37,8 +35,12 @@ export default function LiquidityChartTooltip(props: {
     const percentChange = 1.0001 ** (selectedTick - currentTick) - 1 || 0;
 
     let text: string;
-    if (percentChange < 1.0) {
+    if (percentChange > 1000 && x === chartWidth) {
+      text = '∞';
+    } else if (percentChange < 1.0) {
       text = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 1)}%`;
+    } else if (percentChange < 9.0) {
+      text = `${(percentChange + 1).toFixed(2)}x`;
     } else {
       text = `${(percentChange + 1).toFixed(0)}x`;
     }

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -27,7 +27,7 @@ function getPercentageText(percentChange: number) {
   if (percentChange > 1000) {
     return '∞';
   } else if (percentChange < 1.0) {
-    return `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 1)}%`;
+    return `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
   } else if (percentChange < 9.0) {
     return `${(percentChange + 1).toFixed(2)}x`;
   } else {

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -27,19 +27,27 @@ const TooltipContainer = styled.div.attrs((props: { offset: number; chartWidth: 
 
 export default function LiquidityChartTooltip(props: {
   active: boolean;
-  selectedPrice: number;
-  currentPrice: number;
+  selectedTick: number;
+  currentTick: number;
   x: number;
   chartWidth: number;
 }) {
-  const { active, selectedPrice, currentPrice, x, chartWidth } = props;
+  const { active, selectedTick, currentTick, x, chartWidth } = props;
   if (active) {
-    const percentChange = ((selectedPrice - currentPrice) / currentPrice) * 100 || 0;
+    const percentChange = 1.0001 ** (selectedTick - currentTick) - 1 || 0;
+
+    let text: string;
+    if (percentChange < 1.0) {
+      text = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 1)}%`;
+    } else {
+      text = `${(percentChange + 1).toFixed(0)}x`;
+    }
+
     return (
       <TooltipContainer offset={x} chartWidth={chartWidth}>
         <div className='flex flex-col justify-center items-center'>
           <Text size='S' weight='bold'>
-            {(percentChange > 0 ? '+' : '') + roundPercentage(percentChange, 1)}%
+            {text}
           </Text>
         </div>
       </TooltipContainer>

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -23,6 +23,18 @@ const TooltipContainer = styled.div.attrs((props: { offset: number; chartWidth: 
   visibility: visible;
 `;
 
+function getPercentageText(percentChange: number) {
+  if (percentChange > 1000) {
+    return '∞';
+  } else if (percentChange < 1.0) {
+    return `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 1)}%`;
+  } else if (percentChange < 9.0) {
+    return `${(percentChange + 1).toFixed(2)}x`;
+  } else {
+    return `${(percentChange + 1).toFixed(0)}x`;
+  }
+}
+
 export default function LiquidityChartTooltip(props: {
   active: boolean;
   selectedTick: number;
@@ -34,22 +46,13 @@ export default function LiquidityChartTooltip(props: {
   if (active) {
     const percentChange = 1.0001 ** (selectedTick - currentTick) - 1 || 0;
 
-    let text: string;
-    if (percentChange > 1000 && x === chartWidth) {
-      text = '∞';
-    } else if (percentChange < 1.0) {
-      text = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 1)}%`;
-    } else if (percentChange < 9.0) {
-      text = `${(percentChange + 1).toFixed(2)}x`;
-    } else {
-      text = `${(percentChange + 1).toFixed(0)}x`;
-    }
+    const percentageText = getPercentageText(percentChange);
 
     return (
       <TooltipContainer offset={x} chartWidth={chartWidth}>
         <div className='flex flex-col justify-center items-center'>
           <Text size='S' weight='bold'>
-            {text}
+            {percentageText}
           </Text>
         </div>
       </TooltipContainer>

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -71,11 +71,8 @@ export interface UniswapV3PoolBasics {
 export type TickData = {
   tick: number;
   liquidity: Big;
-  amount0: number;
-  amount1: number;
   price1In0: number;
   price0In1: number;
-  totalValueIn0: number;
 };
 
 export type UniswapV3GraphQLTick = {
@@ -453,11 +450,8 @@ export async function calculateTickData(
     tickData.push({
       tick,
       liquidity: new Big(liquidity.toString(10)),
-      amount0: 0,
-      amount1: 0,
       price1In0: price1.mul(decimalFactor).toNumber(),
       price0In1: price0.div(decimalFactor).toNumber(),
-      totalValueIn0: 0,
     });
   }
 

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -23,7 +23,7 @@ import {
 } from '../App';
 import UniswapNFTManagerABI from '../assets/abis/UniswapNFTManager.json';
 import UniswapV3PoolABI from '../assets/abis/UniswapV3Pool.json';
-import { UniswapTicksQuery } from '../util/GraphQL';
+import { UniswapTicksQuery, UniswapTicksQueryWithMetadata } from '../util/GraphQL';
 import { convertBigNumbersForReturnContexts } from '../util/Multicall';
 import { UNISWAP_NONFUNGIBLE_POSITION_MANAGER_ADDRESS } from './constants/Addresses';
 import { BIGQ96, Q96 } from './constants/Values';
@@ -364,14 +364,15 @@ export async function fetchUniswapNFTPositions(
   return result;
 }
 
-export async function calculateTickData(
+async function fetchTickData(
   poolAddress: string,
   poolBasics: UniswapV3PoolBasics,
-  chainId: number
-): Promise<TickData[]> {
-  const tickOffset = Math.floor((BINS_TO_FETCH * poolBasics.tickSpacing) / 2);
-  const minTick = poolBasics.slot0.tick - tickOffset;
-  const maxTick = poolBasics.slot0.tick + tickOffset;
+  chainId: number,
+  minTick?: number,
+  maxTick?: number
+) {
+  if (minTick === undefined) minTick = TickMath.MIN_TICK;
+  if (maxTick === undefined) maxTick = TickMath.MAX_TICK;
 
   let theGraphClient = theGraphUniswapV3Client;
   switch (chainId) {
@@ -385,97 +386,80 @@ export async function calculateTickData(
       theGraphClient = theGraphUniswapV3GoerliClient;
       break;
     case mainnet.id:
-    default:
       break;
+    default:
+      throw new Error(`TheGraph endpoint is unknown for chainId ${chainId}`);
   }
 
-  const uniswapV3GraphQLTicksQueryResponse = (await theGraphClient.query({
-    query: UniswapTicksQuery,
+  const initialQueryResponse = (await theGraphClient.query({
+    query: UniswapTicksQueryWithMetadata,
     variables: {
       poolAddress: poolAddress.toLowerCase(),
       minTick: minTick,
       maxTick: maxTick,
     },
   })) as ApolloQueryResult<UniswapV3GraphQLTicksQueryResponse>;
-  if (!uniswapV3GraphQLTicksQueryResponse.data.pools) return [];
-  const poolLiquidityData = uniswapV3GraphQLTicksQueryResponse.data.pools[0];
+  if (!initialQueryResponse.data.pools) return null;
+
+  const poolLiquidityData = initialQueryResponse.data.pools[0];
+  const tickData = poolLiquidityData.ticks.concat();
+
+  while (true) {
+    const queryResponse = (await theGraphClient.query({
+      query: UniswapTicksQuery,
+      variables: {
+        poolAddress: poolAddress.toLowerCase(),
+        minTick: Number(tickData[tickData.length - 1].tickIdx),
+        maxTick: maxTick,
+      },
+    })) as ApolloQueryResult<UniswapV3GraphQLTicksQueryResponse>;
+    if (!queryResponse.data.pools) break;
+
+    tickData.push(...queryResponse.data.pools[0].ticks);
+    if (queryResponse.data.pools[0].ticks.length < 1000) break;
+  }
+
+  return {
+    ...poolLiquidityData,
+    ticks: tickData,
+  };
+}
+
+export async function calculateTickData(
+  poolAddress: string,
+  poolBasics: UniswapV3PoolBasics,
+  chainId: number
+): Promise<TickData[]> {
+  const poolLiquidityData = await fetchTickData(poolAddress, poolBasics, chainId);
+  if (poolLiquidityData === null) return [];
 
   const token0Decimals = Number(poolLiquidityData.token0.decimals);
   const token1Decimals = Number(poolLiquidityData.token1.decimals);
   const decimalFactor = new Big(10 ** (token1Decimals - token0Decimals));
-
-  const currentLiquidity = new Big(poolLiquidityData.liquidity);
-  const currentTick = Number(poolLiquidityData.tick);
   const rawTicksData = poolLiquidityData.ticks;
 
-  const tickDataLeft: TickData[] = [];
-  const tickDataRight: TickData[] = [];
+  const tickData: TickData[] = [];
 
-  // MARK -- filling out data for ticks *above* the current tick
-  let liquidity = currentLiquidity;
-  let splitIdx = rawTicksData.length;
+  let liquidity = JSBI.BigInt('0');
 
-  for (let i = 0; i < rawTicksData.length; i += 1) {
-    const rawTickData = rawTicksData[i];
-    const tick = Number(rawTickData.tickIdx);
-    if (tick <= currentTick) continue;
+  for (const element of rawTicksData) {
+    const tick = Number(element.tickIdx);
+    const liquidityNet = JSBI.BigInt(element.liquidityNet);
+    const price0 = new Big(element.price0);
+    const price1 = new Big(element.price1);
 
-    // remember the first index above current tick so that search below current tick is more efficient
-    if (i < splitIdx) splitIdx = i;
+    liquidity = JSBI.ADD(liquidity, liquidityNet);
 
-    liquidity = liquidity.plus(new Big(rawTickData.liquidityNet));
-    const price0 = new Big(rawTickData.price0);
-    const price1 = new Big(rawTickData.price1);
-
-    const sqrtPL = price0.sqrt();
-    const sqrtPU = price0.mul(new Big(1.0001).pow(poolBasics.tickSpacing)).sqrt();
-    const amount0 = liquidity
-      .mul(ONE.div(sqrtPL).minus(ONE.div(sqrtPU)))
-      .div(10 ** token0Decimals)
-      .toNumber();
-
-    tickDataRight.push({
+    tickData.push({
       tick,
-      liquidity,
-      amount0: amount0,
+      liquidity: new Big(liquidity.toString(10)),
+      amount0: 0,
       amount1: 0,
       price1In0: price1.mul(decimalFactor).toNumber(),
       price0In1: price0.div(decimalFactor).toNumber(),
-      totalValueIn0: amount0,
+      totalValueIn0: 0,
     });
   }
-
-  // MARK -- filling out data for ticks *below* the current tick
-  liquidity = currentLiquidity;
-
-  for (let i = splitIdx - 1; i >= 0; i -= 1) {
-    const rawTickData = rawTicksData[i];
-    const tick = Number(rawTickData.tickIdx);
-    if (tick > currentTick) continue;
-
-    liquidity = liquidity.minus(new Big(rawTickData.liquidityNet));
-    const price0 = new Big(rawTickData.price0);
-    const price1 = new Big(rawTickData.price1);
-
-    const sqrtPL = price0.sqrt();
-    const sqrtPU = price0.mul(new Big(1.0001).pow(poolBasics.tickSpacing)).sqrt();
-    const amount1 = liquidity
-      .mul(sqrtPU.minus(sqrtPL))
-      .div(10 ** token1Decimals)
-      .toNumber();
-
-    tickDataLeft.push({
-      tick,
-      liquidity,
-      amount0: 0,
-      amount1: amount1,
-      price1In0: price1.mul(decimalFactor).toNumber(),
-      price0In1: price0.div(decimalFactor).toNumber(),
-      totalValueIn0: amount1 * price1.mul(decimalFactor).toNumber(),
-    });
-  }
-
-  const tickData = tickDataLeft.reverse().concat(...tickDataRight);
 
   return tickData;
 }

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -28,8 +28,6 @@ import { convertBigNumbersForReturnContexts } from '../util/Multicall';
 import { UNISWAP_NONFUNGIBLE_POSITION_MANAGER_ADDRESS } from './constants/Addresses';
 import { BIGQ96, Q96 } from './constants/Values';
 
-const BINS_TO_FETCH = 500;
-const ONE = new Big('1.0');
 const FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
 const POOL_INIT_CODE_HASH = '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54';
 

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -30,6 +30,7 @@ import { BIGQ96, Q96 } from './constants/Values';
 
 const FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
 const POOL_INIT_CODE_HASH = '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54';
+const MAX_TICKS_PER_QUERY = 1000;
 
 export type UniswapPosition = {
   lower: number;
@@ -411,7 +412,7 @@ async function fetchTickData(
     if (!queryResponse.data.pools) break;
 
     tickData.push(...queryResponse.data.pools[0].ticks);
-    if (queryResponse.data.pools[0].ticks.length < 1000) break;
+    if (queryResponse.data.pools[0].ticks.length < MAX_TICKS_PER_QUERY) break;
   }
 
   return {

--- a/earn/src/pages/BoostPage.tsx
+++ b/earn/src/pages/BoostPage.tsx
@@ -91,7 +91,6 @@ export default function BoostPage() {
       const { token0, token1, tickLower, tickUpper } = position;
 
       const minPrice = tickToPrice(tickLower, token0.decimals, token1.decimals, true);
-
       const maxPrice = tickToPrice(tickUpper, token0.decimals, token1.decimals, true);
 
       const sqrtPriceX96 = slot0Data[index][0];
@@ -132,6 +131,9 @@ export default function BoostPage() {
         isDeposit: isDeposit,
         poolAddress: poolAddress,
         currentPrice: currentPrice,
+        tickLower,
+        tickUpper,
+        currentTick,
       };
     });
   }, [nonZeroUniswapNFTPositions, slot0Data]);
@@ -151,7 +153,9 @@ export default function BoostPage() {
               token1={position.token1}
               minPrice={position.minPrice}
               maxPrice={position.maxPrice}
-              currentPrice={position.currentPrice}
+              minTick={position.tickLower}
+              maxTick={position.tickUpper}
+              currentTick={position.currentTick}
               amount0={position.amount0}
               amount1={position.amount1}
               amount0Percent={position.amount0Percent}

--- a/earn/src/util/GraphQL.ts
+++ b/earn/src/util/GraphQL.ts
@@ -50,7 +50,7 @@ export const UniswapPairValueQuery = gql`
   }
 `;
 
-export const UniswapTicksQuery = gql`
+export const UniswapTicksQueryWithMetadata = gql`
   query GetUniswapTicks($poolAddress: String!, $minTick: BigInt!, $maxTick: BigInt!) {
     pools(where: { id: $poolAddress }) {
       token0 {
@@ -61,7 +61,20 @@ export const UniswapTicksQuery = gql`
       }
       liquidity
       tick
-      ticks(first: 1000, orderBy: tickIdx, where: { tickIdx_gt: $minTick, tickIdx_lt: $maxTick }) {
+      ticks(first: 1000, orderBy: tickIdx, where: { tickIdx_gte: $minTick, tickIdx_lte: $maxTick }) {
+        tickIdx
+        liquidityNet
+        price0
+        price1
+      }
+    }
+  }
+`;
+
+export const UniswapTicksQuery = gql`
+  query GetUniswapTicks($poolAddress: String!, $minTick: BigInt!, $maxTick: BigInt!) {
+    pools(where: { id: $poolAddress }) {
+      ticks(first: 1000, orderBy: tickIdx, where: { tickIdx_gte: $minTick, tickIdx_lte: $maxTick }) {
         tickIdx
         liquidityNet
         price0


### PR DESCRIPTION
Liquidity chart now works for positions that span 0 --> infinity

One problem I'm seeing now is when you switch to a different wallet, you have to refresh the page in order for the graphs to refresh properly.