### PR TITLE
Fix percentage conditional to avoid premature infinity

### DIFF
--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -34,22 +34,22 @@ export default function LiquidityChartTooltip(props: {
   if (active) {
     const percentChange = 1.0001 ** (selectedTick - currentTick) - 1 || 0;
 
-    let text: string;
+    let percentText: string;
     if (percentChange > 1000 && x === chartWidth) {
-      text = '∞';
+      percentText = '∞';
     } else if (percentChange < 1.0) {
-      text = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
+      percentText = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
     } else if (percentChange < 9.0) {
-      text = `${(percentChange + 1).toFixed(2)}x`;
+      percentText = `${(percentChange + 1).toFixed(2)}x`;
     } else {
-      text = `${(percentChange + 1).toFixed(0)}x`;
+      percentText = `${(percentChange + 1).toFixed(0)}x`;
     }
 
     return (
       <TooltipContainer offset={x} chartWidth={chartWidth}>
         <div className='flex flex-col justify-center items-center'>
           <Text size='S' weight='bold'>
-            {text}
+            {percentText}
           </Text>
         </div>
       </TooltipContainer>

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -34,22 +34,22 @@ export default function LiquidityChartTooltip(props: {
   if (active) {
     const percentChange = 1.0001 ** (selectedTick - currentTick) - 1 || 0;
 
-    let percentText: string;
+    let percentageText: string;
     if (percentChange > 1000 && x === chartWidth) {
-      percentText = '∞';
+      percentageText = '∞';
     } else if (percentChange < 1.0) {
-      percentText = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
+      percentageText = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
     } else if (percentChange < 9.0) {
-      percentText = `${(percentChange + 1).toFixed(2)}x`;
+      percentageText = `${(percentChange + 1).toFixed(2)}x`;
     } else {
-      percentText = `${(percentChange + 1).toFixed(0)}x`;
+      percentageText = `${(percentChange + 1).toFixed(0)}x`;
     }
 
     return (
       <TooltipContainer offset={x} chartWidth={chartWidth}>
         <div className='flex flex-col justify-center items-center'>
           <Text size='S' weight='bold'>
-            {percentText}
+            {percentageText}
           </Text>
         </div>
       </TooltipContainer>

--- a/earn/src/components/boost/LiquidityChartTooltip.tsx
+++ b/earn/src/components/boost/LiquidityChartTooltip.tsx
@@ -23,18 +23,6 @@ const TooltipContainer = styled.div.attrs((props: { offset: number; chartWidth: 
   visibility: visible;
 `;
 
-function getPercentageText(percentChange: number) {
-  if (percentChange > 1000) {
-    return '∞';
-  } else if (percentChange < 1.0) {
-    return `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
-  } else if (percentChange < 9.0) {
-    return `${(percentChange + 1).toFixed(2)}x`;
-  } else {
-    return `${(percentChange + 1).toFixed(0)}x`;
-  }
-}
-
 export default function LiquidityChartTooltip(props: {
   active: boolean;
   selectedTick: number;
@@ -46,13 +34,22 @@ export default function LiquidityChartTooltip(props: {
   if (active) {
     const percentChange = 1.0001 ** (selectedTick - currentTick) - 1 || 0;
 
-    const percentageText = getPercentageText(percentChange);
+    let text: string;
+    if (percentChange > 1000 && x === chartWidth) {
+      text = '∞';
+    } else if (percentChange < 1.0) {
+      text = `${percentChange > 0 ? '+' : ''}${roundPercentage(100 * percentChange, 2)}%`;
+    } else if (percentChange < 9.0) {
+      text = `${(percentChange + 1).toFixed(2)}x`;
+    } else {
+      text = `${(percentChange + 1).toFixed(0)}x`;
+    }
 
     return (
       <TooltipContainer offset={x} chartWidth={chartWidth}>
         <div className='flex flex-col justify-center items-center'>
           <Text size='S' weight='bold'>
-            {percentageText}
+            {text}
           </Text>
         </div>
       </TooltipContainer>


### PR DESCRIPTION
We only want to show infinity on the tooltip if the cursor is all the way to the right (it doesn't make sense for multiple x values to refer to infinity). This fixes that.