### PR TITLE
Making the units for the balance section of portfolio metrics smaller

### DIFF
--- a/earn/src/components/portfolio/PortfolioMetrics.tsx
+++ b/earn/src/components/portfolio/PortfolioMetrics.tsx
@@ -71,7 +71,7 @@ export default function PortfolioMetrics(props: PortfolioMetricsProps) {
           <Display size='L' className='inline-block mr-0.5'>
             {formatTokenAmount(totalBalance, 3)}
           </Display>
-          <Display size='S' className='inline-block ml-0.5'>
+          <Display size='XS' className='inline-block ml-0.5'>
             {activeAsset?.symbol || ''}
           </Display>
         </div>


### PR DESCRIPTION
<img width="347" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/85e0892d-5079-4de1-9228-88bc2f155dab">
