### PR TITLE
Fixing 1x boost interest calculation

### DIFF
--- a/earn/src/components/boost/ImportBoostWidget.tsx
+++ b/earn/src/components/boost/ImportBoostWidget.tsx
@@ -314,7 +314,7 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
   }, [activeChain.id, cardInfo, setTwentyFourHourPoolData]);
 
   const dailyInterestUSD = useMemo(() => {
-    if (!apr0 || !apr1 || !tokenQuotes) {
+    if (apr0 == null || apr1 == null || !tokenQuotes) {
       return null;
     }
     const dailyInterest0 = (apr0 / 365) * (cardInfo.amount0() * (boostFactor - 1));


### PR DESCRIPTION
Previously, we would set it to null if apr0 or apr1 was 0 when we should have only done so if apr0 or apr1 was null.