### PR TITLE
Fixing long-standing selected lending pair index bug

### DIFF
--- a/earn/src/components/portfolio/modal/WithdrawModal.tsx
+++ b/earn/src/components/portfolio/modal/WithdrawModal.tsx
@@ -172,6 +172,8 @@ export default function WithdrawModal(props: WithdrawModalProps) {
             options={tokens}
             selectedOption={selectedToken}
             onSelect={(option) => {
+              // Reset the selected pair
+              setSelectedPairIdx(0);
               setSelectedToken(option);
               setInputValue(['', false]);
             }}


### PR DESCRIPTION
Fixing a long-standing bug that occurred when the user switched tokens after switching to a lending pair whose index is greater than the length of the lending pairs of the newly selected token.