### PR TITLE
Attempting to fix gh actions

### DIFF
--- a/.github/workflows/test-earn.yml
+++ b/.github/workflows/test-earn.yml
@@ -16,4 +16,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - run: cd shared && yarn install && yarn build && cd ../earn && yarn install && yarn test
+      - run: |
+          yarn global add node-gyp
+          cd shared && yarn install && yarn build && cd ../earn && yarn install && yarn test

--- a/.github/workflows/test-prime.yml
+++ b/.github/workflows/test-prime.yml
@@ -16,4 +16,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - run: cd shared && yarn install && yarn build && cd ../prime && yarn install && yarn test
+      - run: |
+          yarn global add node-gyp
+          cd shared && yarn install && yarn build && cd ../prime && yarn install && yarn test

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -16,4 +16,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - run: cd shared && yarn install && yarn test
+      - run: |
+          yarn global add node-gyp
+          cd shared && yarn install && yarn test


### PR DESCRIPTION
Yarn keeps complaining about node-gyp not being installed and recommends that we install it globally.