### PR TITLE
Fixing modals on smaller screens

### DIFF
--- a/shared/src/components/common/Modal.tsx
+++ b/shared/src/components/common/Modal.tsx
@@ -233,7 +233,6 @@ const ModalPanelWrapper = styled.div.attrs((props: { maxHeight?: string; maxWidt
   max-height: min(${(props) => props.maxHeight || '570px'}, 90vh);
   min-width: 400px;
   max-width: ${(props) => props.maxWidth || '450px'};
-  max-height: ${(props) => props.maxHeight || '570px'};
   height: max-content;
   &::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
Fixing a bug that caused modals' height on smaller screens to extend beyond the screen.