### PR TITLE
Fix Boost>Collect and Boost>Burn, now just need dynamic ptr

### DIFF
--- a/earn/src/components/boost/CollectFeesWidget.tsx
+++ b/earn/src/components/boost/CollectFeesWidget.tsx
@@ -7,7 +7,7 @@ import { borrowerNftAbi } from 'shared/lib/abis/BorrowerNft';
 import { FilledGradientButton } from 'shared/lib/components/common/Buttons';
 import TokenIcon from 'shared/lib/components/common/TokenIcon';
 import { Text, Display } from 'shared/lib/components/common/Typography';
-import { ALOE_II_BORROWER_NFT_ADDRESS } from 'shared/lib/data/constants/ChainSpecific';
+import { ALOE_II_BOOST_MANAGER_ADDRESS, ALOE_II_BORROWER_NFT_ADDRESS } from 'shared/lib/data/constants/ChainSpecific';
 import { GREY_700, GREY_800 } from 'shared/lib/data/constants/Colors';
 import { GNFormat } from 'shared/lib/data/GoodNumber';
 import { formatUSD } from 'shared/lib/util/Numbers';
@@ -49,17 +49,19 @@ export default function CollectFeesWidget(props: CollectFeesWidgetProps) {
   const { activeChain } = useContext(ChainContext);
 
   const modifyData = useMemo(() => {
-    return ethers.utils.defaultAbiCoder.encode(
+    const inner = ethers.utils.defaultAbiCoder.encode(
       ['int24', 'int24'],
       [cardInfo.position.lower, cardInfo.position.upper]
     ) as `0x${string}`;
+    const actionId = 1;
+    return ethers.utils.defaultAbiCoder.encode(['uint8', 'bytes'], [actionId, inner]) as `0x${string}`;
   }, [cardInfo]);
 
   const { config: configBurn } = usePrepareContractWrite({
     address: ALOE_II_BORROWER_NFT_ADDRESS[activeChain.id],
     abi: borrowerNftAbi,
     functionName: 'modify',
-    args: undefined, // [ethers.BigNumber.from(cardInfo.nftTokenId || 0), 1, modifyData], // TODO:
+    args: [cardInfo.owner, [cardInfo.nftTokenPtr!], [ALOE_II_BOOST_MANAGER_ADDRESS[activeChain.id]], [modifyData], [0]],
     chainId: activeChain.id,
     enabled: !JSBI.equal(cardInfo?.position.liquidity, JSBI.BigInt(0)),
   });

--- a/earn/src/components/boost/ImportBoostWidget.tsx
+++ b/earn/src/components/boost/ImportBoostWidget.tsx
@@ -197,7 +197,6 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
     }
   }
 
-  // TODO: use async effect?
   useEffect(() => {
     (async () => {
       let quoteDataResponse: AxiosResponse<PriceRelayLatestResponse>;

--- a/earn/src/components/boost/ImportBoostWidget.tsx
+++ b/earn/src/components/boost/ImportBoostWidget.tsx
@@ -316,10 +316,10 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
   }, [apr0, apr1, boostFactor, cardInfo, tokenQuotes]);
 
   const nftTokenId = ethers.BigNumber.from(cardInfo?.nftTokenId || 0);
-  const initializationData = useMemo(() => {
+  const modifyData = useMemo(() => {
     if (!cardInfo) return undefined;
     const { position } = cardInfo;
-    return ethers.utils.defaultAbiCoder.encode(
+    const inner = ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'int24', 'int24', 'uint128', 'uint24'],
       [
         cardInfo.nftTokenId,
@@ -329,6 +329,8 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
         (boostFactor * 10000).toFixed(0),
       ]
     ) as `0x${string}`;
+    const actionId = 0;
+    return ethers.utils.defaultAbiCoder.encode(['uint8', 'bytes'], [actionId, inner]) as `0x${string}`;
   }, [cardInfo, boostFactor]);
   const enableHooks = cardInfo !== undefined;
 
@@ -350,7 +352,7 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
   });
   const managerIsCorrect = Boolean(manager) && manager === necessaryManager;
   const shouldWriteManager = !isFetchingManager && Boolean(manager) && !managerIsCorrect;
-  const shouldMint = !isFetchingManager && Boolean(initializationData) && managerIsCorrect;
+  const shouldMint = !isFetchingManager && Boolean(modifyData) && managerIsCorrect;
 
   // We need the Boost Manager to be approved, so if it's not, prepare to write
   const { config: configWriteManager } = usePrepareContractWrite({
@@ -384,6 +386,15 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
     },
   });
 
+  const { data: nextNftPointerIndex } = useContractRead({
+    address: ALOE_II_BORROWER_NFT_ADDRESS[activeChain.id],
+    abi: borrowerNftAbi,
+    functionName: 'balanceOf',
+    args: [userAddress ?? '0x'],
+    chainId: activeChain.id,
+    enabled: enableHooks && Boolean(userAddress),
+  });
+
   // Prepare for actual import/mint transaction
   const borrowerNft = useMemo(() => new ethers.utils.Interface(borrowerNftAbi), []);
   // First, we `mint` so that they have a `Borrower` to put stuff in
@@ -396,22 +407,14 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
   }, [borrowerNft, userAddress, cardInfo]);
   // Then we `modify`, calling the BoostManager to import the Uniswap position
   const encodedModify = useMemo(() => {
-    if (!userAddress) return undefined;
+    if (!userAddress || nextNftPointerIndex === undefined) return undefined;
     const owner = userAddress;
-    const indices = [0]; // TODO:
+    const indices = [nextNftPointerIndex];
     const managers = [ALOE_II_BOOST_MANAGER_ADDRESS[activeChain.id]];
-    const datas = [
-      ethers.utils.defaultAbiCoder.encode(
-        ['uint8', 'bytes'],
-        [
-          0, // actionId 0 means mint
-          initializationData,
-        ]
-      ) as `0x${string}`,
-    ];
+    const datas = [modifyData];
     const antes = [ante.div(1e13)];
     return borrowerNft.encodeFunctionData('modify', [owner, indices, managers, datas, antes]) as `0x${string}`;
-  }, [borrowerNft, userAddress, activeChain, initializationData, ante]);
+  }, [borrowerNft, userAddress, activeChain, nextNftPointerIndex, modifyData, ante]);
 
   const {
     config: configMint,

--- a/earn/src/data/Uniboost.ts
+++ b/earn/src/data/Uniboost.ts
@@ -34,8 +34,9 @@ export enum BoostCardType {
 export class BoostCardInfo {
   constructor(
     public readonly cardType: BoostCardType,
+    public readonly owner: Address,
     public readonly nftTokenId: number | string,
-    public readonly nftTokenPtr: number,
+    public readonly nftTokenPtr: number | null,
     public readonly uniswapPool: Address,
     public readonly currentTick: number,
     public readonly token0: Token,
@@ -52,6 +53,7 @@ export class BoostCardInfo {
   static from(boostCardInfo: BoostCardInfo, marginAccount: MarginAccount, position: UniswapPosition): BoostCardInfo {
     return new BoostCardInfo(
       boostCardInfo.cardType,
+      boostCardInfo.owner,
       boostCardInfo.nftTokenId,
       boostCardInfo.nftTokenPtr,
       boostCardInfo.uniswapPool,
@@ -71,6 +73,7 @@ export class BoostCardInfo {
   static withColors(boostCardInfo: BoostCardInfo, color0: string, color1: string): BoostCardInfo {
     return new BoostCardInfo(
       boostCardInfo.cardType,
+      boostCardInfo.owner,
       boostCardInfo.nftTokenId,
       boostCardInfo.nftTokenPtr,
       boostCardInfo.uniswapPool,

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -37,6 +37,7 @@ export type UniswapPosition = {
 export type UniswapPositionPrior = Omit<UniswapPosition, 'liquidity'>;
 
 export type UniswapNFTPosition = UniswapPosition & {
+  owner: Address;
   operator: string;
   token0: Token;
   token1: Token;
@@ -313,10 +314,12 @@ export async function fetchUniswapNFTPosition(
     provider
   );
   const position = await nftManager.positions(tokenId);
+  const owner = await nftManager.ownerOf(tokenId);
   const token0 = getToken(chainId, position[2]);
   const token1 = getToken(chainId, position[3]);
   if (token0 === undefined || token1 === undefined) return undefined;
   const uniswapPosition: UniswapNFTPosition = {
+    owner,
     operator: position[1],
     token0,
     token1,
@@ -330,7 +333,7 @@ export async function fetchUniswapNFTPosition(
 }
 
 export async function fetchUniswapNFTPositions(
-  userAddress: string,
+  userAddress: Address,
   provider: Provider
 ): Promise<Map<number, UniswapNFTPosition>> {
   const chainId = (await provider.getNetwork()).chainId;
@@ -394,6 +397,7 @@ export async function fetchUniswapNFTPositions(
     const token1 = getToken(chainId, position[3]);
     if (token0 === undefined || token1 === undefined) continue;
     const uniswapPosition: UniswapNFTPosition = {
+      owner: userAddress,
       operator: position[1],
       token0,
       token1,

--- a/earn/src/pages/BoostPage.tsx
+++ b/earn/src/pages/BoostPage.tsx
@@ -115,6 +115,7 @@ export default function BoostPage() {
           const res = await fetchBoostBorrower(chainId, provider, borrowerAddress);
           return new BoostCardInfo(
             BoostCardType.BOOST_NFT,
+            userAddress,
             tokenIds[i],
             indices[i],
             res.borrower.uniswapPool as Address,
@@ -178,6 +179,7 @@ export default function BoostPage() {
         address: ALOE_II_FACTORY_ADDRESS[activeChain.id],
         functionName: 'getMarket',
         args: [computePoolAddress({ ...position, chainId: activeChain.id })],
+        chainId: activeChain.id,
       } as const;
     });
   }, [activeChain.id, uniswapNFTPositions]);
@@ -213,7 +215,12 @@ export default function BoostPage() {
                      CREATE UNISWAP CARD INFOS
   //////////////////////////////////////////////////////////////*/
   const uniswapCardInfos: BoostCardInfo[] = useMemo(() => {
-    if (slot0Data === undefined || slot0Data.length !== uniswapNFTPositions.length || marketDatas === undefined) {
+    if (
+      slot0Data === undefined ||
+      slot0Data.length !== uniswapNFTPositions.length ||
+      marketDatas === undefined ||
+      !userAddress
+    ) {
       return [];
     }
     return uniswapNFTPositions
@@ -223,8 +230,9 @@ export default function BoostPage() {
 
         return new BoostCardInfo(
           BoostCardType.UNISWAP_NFT,
+          userAddress,
           position.tokenId,
-          -1, // TODO:
+          null,
           computePoolAddress({ ...position, chainId: activeChain.id }),
           currentTick,
           position.token0,
@@ -240,7 +248,7 @@ export default function BoostPage() {
         );
       })
       .filter((info) => info.lender0 !== ethers.constants.AddressZero || info.lender1 !== ethers.constants.AddressZero);
-  }, [slot0Data, uniswapNFTPositions, marketDatas, activeChain.id, colors]);
+  }, [slot0Data, uniswapNFTPositions, marketDatas, userAddress, activeChain.id, colors]);
 
   /*//////////////////////////////////////////////////////////////
                       CREATE BOOSTED CARD INFOS

--- a/earn/src/pages/boost/ImportBoostPage.tsx
+++ b/earn/src/pages/boost/ImportBoostPage.tsx
@@ -140,8 +140,9 @@ export default function ImportBoostPage() {
     const currentTick = slot0.tick;
     return new BoostCardInfo(
       BoostCardType.UNISWAP_NFT,
+      uniswapNftPosition.owner,
       uniswapNftPosition.tokenId,
-      -1, // TODO:
+      null,
       poolAddress,
       currentTick,
       uniswapNftPosition.token0,

--- a/earn/src/pages/boost/ManageBoostPage.tsx
+++ b/earn/src/pages/boost/ManageBoostPage.tsx
@@ -2,19 +2,16 @@ import { useContext, useEffect, useState } from 'react';
 
 import { SendTransactionResult } from '@wagmi/core';
 import axios, { AxiosResponse } from 'axios';
-import { ethers } from 'ethers';
 import JSBI from 'jsbi';
 import { useNavigate, useParams } from 'react-router-dom';
-import { borrowerNftAbi } from 'shared/lib/abis/BorrowerNft';
 import ArrowLeft from 'shared/lib/assets/svg/ArrowLeft';
 import AppPage from 'shared/lib/components/common/AppPage';
 import { FilledGradientButton } from 'shared/lib/components/common/Buttons';
 import { Text } from 'shared/lib/components/common/Typography';
-import { ALOE_II_BORROWER_NFT_ADDRESS } from 'shared/lib/data/constants/ChainSpecific';
 import { useChainDependentState } from 'shared/lib/data/hooks/UseChainDependentState';
 import useSafeState from 'shared/lib/data/hooks/UseSafeState';
 import styled from 'styled-components';
-import { Address, useContractRead, useProvider } from 'wagmi';
+import { Address, useAccount, useProvider } from 'wagmi';
 
 import { ChainContext } from '../../App';
 import BoostCard from '../../components/boost/BoostCard';
@@ -53,6 +50,7 @@ export default function ManageBoostPage() {
   const [pendingTxn, setPendingTxn] = useState<SendTransactionResult | null>(null);
   const [pendingTxnModalStatus, setPendingTxnModalStatus] = useSafeState<PendingTxnModalStatus | null>(null);
   const [isBurnModalOpen, setIsBurnModalOpen] = useState(false);
+  const { address: userAddress } = useAccount();
 
   const navigate = useNavigate();
 
@@ -62,6 +60,7 @@ export default function ManageBoostPage() {
     }
   }, [cardInfo, navigate]);
 
+  // TODO: useAsyncEffect?
   useEffect(() => {
     (async () => {
       if (!pendingTxn) return;
@@ -76,6 +75,7 @@ export default function ManageBoostPage() {
     })();
   }, [pendingTxn, setIsPendingTxnModalOpen, setPendingTxnModalStatus]);
 
+  // TODO: useAsyncEffect?
   useEffect(() => {
     (async () => {
       if (!cardInfo) return;
@@ -88,6 +88,7 @@ export default function ManageBoostPage() {
     })();
   }, [cardInfo, setColors]);
 
+  // TODO: useAsyncEffect?
   useEffect(() => {
     if (!cardInfo) return;
     (async () => {
@@ -107,14 +108,17 @@ export default function ManageBoostPage() {
 
   const borrowerAddress = nftTokenId?.slice(0, 42);
 
+  // TODO: useAsyncEffect?
   useEffect(() => {
     if (!borrowerAddress || !nftTokenId) return;
     (async () => {
+      if (!userAddress) return;
       const res = await fetchBoostBorrower(activeChain.id, provider, borrowerAddress as Address);
       const boostCardInfo = new BoostCardInfo(
         BoostCardType.BOOST_NFT,
+        userAddress,
         nftTokenId,
-        -1, // TODO:
+        1, // TODO:
         res.borrower.uniswapPool as Address,
         sqrtRatioToTick(res.borrower.sqrtPriceX96),
         res.borrower.token0,
@@ -129,7 +133,7 @@ export default function ManageBoostPage() {
       );
       setCardInfo(boostCardInfo);
     })();
-  }, [activeChain.id, borrowerAddress, nftTokenId, provider, setCardInfo]);
+  }, [userAddress, activeChain.id, borrowerAddress, nftTokenId, provider, setCardInfo]);
 
   // Handled separately from the above useEffect because we don't want to re-fetch the borrower
   useEffect(() => {
@@ -165,7 +169,6 @@ export default function ManageBoostPage() {
         <BurnBoostModal
           isOpen={isBurnModalOpen}
           cardInfo={cardInfo}
-          nftTokenId={nftTokenId}
           setIsOpen={() => {
             setIsBurnModalOpen(false);
           }}

--- a/earn/src/pages/boost/ManageBoostPage.tsx
+++ b/earn/src/pages/boost/ManageBoostPage.tsx
@@ -60,7 +60,6 @@ export default function ManageBoostPage() {
     }
   }, [cardInfo, navigate]);
 
-  // TODO: useAsyncEffect?
   useEffect(() => {
     (async () => {
       if (!pendingTxn) return;
@@ -75,7 +74,6 @@ export default function ManageBoostPage() {
     })();
   }, [pendingTxn, setIsPendingTxnModalOpen, setPendingTxnModalStatus]);
 
-  // TODO: useAsyncEffect?
   useEffect(() => {
     (async () => {
       if (!cardInfo) return;
@@ -88,7 +86,6 @@ export default function ManageBoostPage() {
     })();
   }, [cardInfo, setColors]);
 
-  // TODO: useAsyncEffect?
   useEffect(() => {
     if (!cardInfo) return;
     (async () => {
@@ -108,11 +105,9 @@ export default function ManageBoostPage() {
 
   const borrowerAddress = nftTokenId?.slice(0, 42);
 
-  // TODO: useAsyncEffect?
   useEffect(() => {
-    if (!borrowerAddress || !nftTokenId) return;
+    if (!borrowerAddress || !nftTokenId || !userAddress) return;
     (async () => {
-      if (!userAddress) return;
       const res = await fetchBoostBorrower(activeChain.id, provider, borrowerAddress as Address);
       const boostCardInfo = new BoostCardInfo(
         BoostCardType.BOOST_NFT,


### PR DESCRIPTION
Updated transaction data for Collect and Burn, and tested it with one position. Only thing missing now is fetching the token's index in the BorrowerNFT array (see TODO on line 121 of `ManageBoostPage`)

There are numerous other improvements to be made, but it's working for now.
- lots of useEffects that don't handle async properly??
- better way of fetching BorrowerNFTs
- use separate data classes for Uniswap NFTs and Boosted Positions
- etc.