### PR TITLE
Fixing bug with tokenPtr not being set

### DIFF
--- a/earn/src/pages/boost/ManageBoostPage.tsx
+++ b/earn/src/pages/boost/ManageBoostPage.tsx
@@ -149,9 +149,11 @@ export default function ManageBoostPage() {
   useEffect(() => {
     if (!cardInfo || !colors?.token0 || !colors?.token1) return;
     if (cardInfo.color0 === colors.token0 || cardInfo.color1 === colors.token1) return;
+    // Only update the card info if the tokenPtr matches
+    if (cardInfo.nftTokenPtr !== tokenPtr) return;
     const boostCardWithColors = BoostCardInfo.withColors(cardInfo, colors.token0, colors.token1);
     setCardInfo(boostCardWithColors);
-  }, [cardInfo, colors?.token0, colors?.token1, setCardInfo]);
+  }, [cardInfo, tokenPtr, colors?.token0, colors?.token1, setCardInfo]);
 
   const isLoading = !cardInfo || !nftTokenId;
   return (


### PR DESCRIPTION
Currently, there is a bug that causes `tokenPtr` to not always be set causing the burn txn to fail. To fix this, I added an extra check to make sure we don't overwrite the `tokenPtr` value.