### PR TITLE
Always show amount in supply modal

### DIFF
--- a/earn/src/components/lend/modal/SupplyModal.tsx
+++ b/earn/src/components/lend/modal/SupplyModal.tsx
@@ -263,7 +263,7 @@ export default function SupplyModal(props: SupplyModalProps) {
             Summary
           </Text>
           <Text size='XS' color={SECONDARY_COLOR} className='overflow-hidden text-ellipsis'>
-            You're supplying {amount} {selectedRow.asset.symbol} that users can borrow in exchange for{' '}
+            You're supplying {amount || '0'} {selectedRow.asset.symbol} that users can borrow in exchange for{' '}
             {formattedCollateral}. You will earn a variable <strong>{apyPercentage}%</strong> APY on your supplied{' '}
             {selectedRow.asset.symbol}.
           </Text>


### PR DESCRIPTION
Currently, we don't show an amount in the summary when the user has not input anything. Instead, we should show this amount as zero which this PR does. 