### PR TITLE
Utilizing multicall more when fetching lending pair balances

### DIFF
--- a/earn/src/pages/LendPage.tsx
+++ b/earn/src/pages/LendPage.tsx
@@ -168,10 +168,10 @@ export default function LendPage() {
   useEffect(() => {
     (async () => {
       if (!address) return;
-      const results = await Promise.all(lendingPairs.map((p) => getLendingPairBalances(p, address, provider)));
+      const results = await getLendingPairBalances(lendingPairs, address, provider, activeChain.id);
       setLendingPairBalances(results);
     })();
-  }, [provider, address, lendingPairs, setLendingPairBalances]);
+  }, [activeChain.id, address, lendingPairs, provider, setLendingPairBalances]);
 
   const combinedBalances: TokenBalance[] = useMemo(() => {
     if (tokenQuotes.length === 0) {

--- a/earn/src/pages/MarketsPage.tsx
+++ b/earn/src/pages/MarketsPage.tsx
@@ -183,10 +183,10 @@ export default function MarketsPage() {
   useEffect(() => {
     (async () => {
       if (!userAddress) return;
-      const results = await Promise.all(lendingPairs.map((p) => getLendingPairBalances(p, userAddress, provider)));
+      const results = await getLendingPairBalances(lendingPairs, userAddress, provider, activeChain.id);
       setLendingPairBalances(results);
     })();
-  }, [provider, userAddress, lendingPairs, setLendingPairBalances]);
+  }, [activeChain.id, lendingPairs, provider, setLendingPairBalances, userAddress]);
 
   // MARK: Fetch margin accounts
   useEffect(() => {

--- a/earn/src/pages/PortfolioPage.tsx
+++ b/earn/src/pages/PortfolioPage.tsx
@@ -222,10 +222,10 @@ export default function PortfolioPage() {
     (async () => {
       // Checking for loading rather than number of pairs as pairs could be empty even if loading is false
       if (!address || isLoading) return;
-      const results = await Promise.all(lendingPairs.map((p) => getLendingPairBalances(p, address, provider)));
+      const results = await getLendingPairBalances(lendingPairs, address, provider, activeChain.id);
       setLendingPairBalances(results);
     })();
-  }, [provider, address, lendingPairs, isLoading, setLendingPairBalances]);
+  }, [activeChain.id, address, isLoading, lendingPairs, provider, setLendingPairBalances]);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
Currently, we do not fetch lending pair balances very efficiently as we do not fully utilize multicall. This PR aims to fix that by using multicall to its full potential, saving us from doing extra calls.