### PR TITLE
Fixing repay modal loading state

### DIFF
--- a/earn/src/components/lend/modal/content/RepayModalContent.tsx
+++ b/earn/src/components/lend/modal/content/RepayModalContent.tsx
@@ -152,7 +152,7 @@ function ConfirmButton(props: ConfirmButtonProps) {
   if (isPending) {
     confirmButtonState = ConfirmButtonState.WAITING_FOR_TRANSACTION;
   } else if (repayAmount.isZero()) {
-    confirmButtonState = ConfirmButtonState.LOADING;
+    confirmButtonState = ConfirmButtonState.DISABLED;
   } else if (repayAmount.gt(repayTokenBalance)) {
     confirmButtonState = ConfirmButtonState.INSUFFICIENT_FUNDS;
   } else if (repayAmountSpecified.gt(existingLiabilityGN)) {


### PR DESCRIPTION
Currently using loading state in place of disabled when the user has not input a value.