### PR TITLE
Enabling the leaderboard to interface with new API changes for ens

### DIFF
--- a/earn/src/data/LeaderboardResponse.ts
+++ b/earn/src/data/LeaderboardResponse.ts
@@ -1,4 +1,10 @@
+export type LeaderboardEnsEntry = {
+  name: string | null;
+  lastChecked: number;
+};
+
 export type LeaderboardResponseEntry = {
   address: string;
   score: string;
+  ens?: LeaderboardEnsEntry;
 };

--- a/earn/src/pages/LeaderboardPage.tsx
+++ b/earn/src/pages/LeaderboardPage.tsx
@@ -21,6 +21,7 @@ const GREEN_ACCENT = 'rgba(82, 182, 154, 1)';
 
 type LeaderboardEntry = {
   address: string;
+  enName?: string;
   score: GN;
 };
 
@@ -86,6 +87,7 @@ export default function LeaderboardPage() {
       const updatedLeaderboardEntries = leaderboardResponse.data
         .map((entry) => ({
           address: entry.address,
+          ensName: entry.ens?.name,
           score: GN.fromBigNumber(BigNumber.from(entry.score), 18),
         }))
         .filter((entry) => entry.address.toLowerCase() !== DEAD_ADDRESS);
@@ -163,7 +165,7 @@ export default function LeaderboardPage() {
                       </TableBodyCell>
                       <TableBodyCell>
                         {isUser && <UserLabel>You</UserLabel>}
-                        <code>{entry.address}</code>
+                        <code>{entry.enName ?? entry.address}</code>
                       </TableBodyCell>
                       <TableBodyCell>
                         <Display size='XS'>{entry.score.toString(GNFormat.LOSSY_HUMAN)}</Display>


### PR DESCRIPTION
Currently, the leaderboard does not support ens.