### PR TITLE
Refactor handling of LendingPairBalances (prep for BorrowWidget updates)

### DIFF
--- a/earn/src/components/lend/BorrowingWidget.tsx
+++ b/earn/src/components/lend/BorrowingWidget.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 
 import { SendTransactionResult } from '@wagmi/core';
+import TokenIcon from 'shared/lib/components/common/TokenIcon';
 import { Display, Text } from 'shared/lib/components/common/Typography';
 import { GREY_600, GREY_700 } from 'shared/lib/data/constants/Colors';
 import useSafeState from 'shared/lib/data/hooks/UseSafeState';
@@ -72,7 +73,7 @@ const CardRowHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px;
+  padding: 0.5rem 1rem;
   border-bottom: 2px solid ${GREY_600};
 `;
 
@@ -161,7 +162,7 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
     }
     return Object.entries(borrowEntries).reduce((filtered, [key, entries]) => {
       // Filter out entries that don't match the selected collateral
-      const filteredEntries = entries.filter((entry) => entry.collateral.symbol === selectedCollateral.asset.symbol);
+      const filteredEntries = entries.filter((entry) => entry.collateral.equals(selectedCollateral.asset));
       if (filteredEntries.length > 0) {
         // Only add the entry if there are any matching pairs left
         filtered[key] = filteredEntries;
@@ -174,9 +175,7 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
     if (selectedBorrows == null || selectedBorrows.length === 0) {
       return collateralEntries;
     }
-    return collateralEntries.filter((entry) =>
-      selectedBorrows.some((borrow) => borrow.collateral.symbol === entry.asset.symbol)
-    );
+    return collateralEntries.filter((entry) => selectedBorrows.some((borrow) => borrow.collateral.equals(entry.asset)));
   }, [collateralEntries, selectedBorrows]);
 
   return (
@@ -222,9 +221,11 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
                           });
                         }}
                       >
-                        <div className='flex items-end gap-1'>
-                          <Display size='S'>{collateralAmount}</Display>
-                          <Display size='XS'>{collateral.symbol}</Display>
+                        <div className='flex items-center gap-3'>
+                          <TokenIcon token={collateral} />
+                          <Display size='XS'>
+                            {formatTokenAmount(collateralAmount)}&nbsp;&nbsp;{collateral.symbol}
+                          </Display>
                         </div>
                         <Display size='XXS'>{roundPercentage(ltvPercentage, 3)}% LTV</Display>
                       </AvailableContainer>
@@ -267,9 +268,11 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
                       }}
                       className={selectedCollateral === entry ? 'selected' : ''}
                     >
-                      <div className='flex items-end gap-1'>
-                        <Display size='S'>{formatTokenAmount(entry.balance)}</Display>
-                        <Display size='XS'>{entry.asset.symbol}</Display>
+                      <div className='flex items-center gap-3'>
+                        <TokenIcon token={entry.asset} />
+                        <Display size='XS'>
+                          {formatTokenAmount(entry.balance)}&nbsp;&nbsp;{entry.asset.symbol}
+                        </Display>
                       </div>
                       <Display size='XXS'>{ltvText}</Display>
                     </AvailableContainer>
@@ -339,9 +342,11 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
                         className={account === hoveredBorrower ? 'active' : ''}
                       >
                         <Display size='XXS'>{roundedApy}% APR</Display>
-                        <div className='flex items-end gap-1'>
-                          <Display size='S'>{formatTokenAmount(liabilityAmount)}</Display>
-                          <Display size='XS'>{liability.symbol}</Display>
+                        <div className='flex items-center gap-3'>
+                          <Display size='XS'>
+                            {formatTokenAmount(liabilityAmount)}&nbsp;&nbsp;{liability.symbol}
+                          </Display>
+                          <TokenIcon token={liability} />
                         </div>
                       </AvailableContainer>
                     );
@@ -381,6 +386,7 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
                     >
                       <Display size='XXS'>{apyText}</Display>
                       <Display size='XS'>{key}</Display>
+                      {/* TODO: Add token logo here */}
                     </AvailableContainer>
                   );
                 })}

--- a/earn/src/components/lend/SupplyTable.tsx
+++ b/earn/src/components/lend/SupplyTable.tsx
@@ -221,7 +221,7 @@ export default function SupplyTable(props: SupplyTableProps) {
                 <td className='px-4 py-2 text-end whitespace-nowrap'>
                   <div className='text-start'>
                     <Display size='XS'>
-                      {formatTokenAmount(row.totalSupply)} {row.asset.symbol}
+                      {formatTokenAmount(row.totalSupply)}&nbsp;&nbsp;{row.asset.symbol}
                     </Display>
                   </div>
                 </td>
@@ -230,7 +230,7 @@ export default function SupplyTable(props: SupplyTableProps) {
                     <div className='text-end'>
                       <Display size='XS'>${row.suppliableBalanceUsd.toFixed(2)}</Display>
                       <Display size='XXS' color='rgba(130, 160, 182, 1)'>
-                        {formatTokenAmount(row.suppliableBalance)} {row.asset.symbol}
+                        {formatTokenAmount(row.suppliableBalance)}&nbsp;&nbsp;{row.asset.symbol}
                       </Display>
                     </div>
                     <FilledGreyButton
@@ -249,7 +249,7 @@ export default function SupplyTable(props: SupplyTableProps) {
                     <div className='text-end'>
                       <Display size='XS'>${row.suppliedBalanceUsd.toFixed(2)}</Display>
                       <Display size='XXS' color='rgba(130, 160, 182, 1)'>
-                        {formatTokenAmount(row.suppliedBalance)} {row.asset.symbol}
+                        {formatTokenAmount(row.suppliedBalance)}&nbsp;&nbsp;{row.asset.symbol}
                       </Display>
                     </div>
                     <FilledGreyButton

--- a/earn/src/components/portfolio/modal/SendCryptoModal.tsx
+++ b/earn/src/components/portfolio/modal/SendCryptoModal.tsx
@@ -32,7 +32,7 @@ function getConfirmButton(state: ConfirmButtonState, token: Token): { text: stri
   switch (state) {
     case ConfirmButtonState.INVALID_ADDRESS:
       return {
-        text: `Invalid Address`,
+        text: `Couldn't resolve ENS`,
         enabled: false,
       };
     case ConfirmButtonState.INSUFFICIENT_ASSET:
@@ -211,6 +211,11 @@ export default function SendCryptoModal(props: SendCryptoModalProps) {
   const gnSendAmount = GN.fromDecimalString(sendAmountInputValue || '0', selectedOption.decimals);
   const gnSendBalance = GN.fromBigNumber(depositBalance?.value ?? BigNumber.from('0'), selectedOption.decimals);
   const isValidAddress = ethers.utils.isAddress(addressInputValue) || addressInputValue.endsWith('.eth');
+
+  const summaryText = isValidAddress
+    ? `You're sending ${sendAmountInputValue || '0.00'} ${selectedOption.symbol} to ${addressInputValue || '...'}`
+    : "You're not sending anything.";
+
   return (
     <Modal
       isOpen={isOpen}
@@ -277,7 +282,7 @@ export default function SendCryptoModal(props: SendCryptoModalProps) {
             Summary
           </Text>
           <Text size='XS' color={SECONDARY_COLOR} className='overflow-hidden text-ellipsis'>
-            You're sending {sendAmountInputValue || '0.00'} {selectedOption.symbol} to {addressInputValue || '...'}
+            {summaryText}
           </Text>
         </div>
         <div className='w-full'>

--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -1,5 +1,6 @@
 import { ContractCallContext, Multicall } from 'ethereum-multicall';
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
+import JSBI from 'jsbi';
 import { erc20Abi } from 'shared/lib/abis/ERC20';
 import { factoryAbi } from 'shared/lib/abis/Factory';
 import { lenderAbi } from 'shared/lib/abis/Lender';
@@ -14,6 +15,7 @@ import {
 } from 'shared/lib/data/constants/ChainSpecific';
 import { Q32 } from 'shared/lib/data/constants/Values';
 import { FeeTier, NumericFeeTierToEnum } from 'shared/lib/data/FeeTier';
+import { GN } from 'shared/lib/data/GoodNumber';
 import { Kitty } from 'shared/lib/data/Kitty';
 import { Token } from 'shared/lib/data/Token';
 import { getToken } from 'shared/lib/data/TokenData';
@@ -64,6 +66,8 @@ export type LendingPairBalances = {
   kitty0Balance: number;
   kitty1Balance: number;
 };
+
+export type LendingPairBalancesMap = Map<Address, { value: number; gn: GN; form: 'raw' | 'underlying' }>;
 
 export async function getAvailableLendingPairs(
   chainId: number,
@@ -280,113 +284,95 @@ export async function getLendingPairBalances(
   userAddress: string,
   provider: ethers.providers.Provider,
   chainId: number
-): Promise<LendingPairBalances[]> {
+) {
+  const tokenSet = new Set<Token>();
+  lendingPairs.forEach((pair) => {
+    tokenSet.add(pair.token0);
+    tokenSet.add(pair.token1);
+  });
+
   const multicall = new Multicall({
     ethersProvider: provider,
     multicallCustomContractAddress: MULTICALL_ADDRESS[chainId],
   });
-
   const contractCallContexts: ContractCallContext[] = [];
 
+  tokenSet.forEach((token) =>
+    contractCallContexts.push({
+      reference: `${token.address}.balanceOf`,
+      contractAddress: token.address,
+      abi: erc20Abi as any,
+      calls: [{ reference: 'balanceOf', methodName: 'balanceOf', methodParameters: [userAddress] }],
+    })
+  );
+
+  lendingPairs.forEach((lendingPair) =>
+    contractCallContexts.push(
+      {
+        reference: `${lendingPair.kitty0.address}.underlyingBalance`,
+        contractAddress: lendingPair.kitty0.address,
+        abi: lenderAbi as any,
+        calls: [
+          {
+            reference: 'underlyingBalance',
+            methodName: 'underlyingBalance',
+            methodParameters: [userAddress],
+          },
+        ],
+      },
+      {
+        reference: `${lendingPair.kitty1.address}.underlyingBalance`,
+        contractAddress: lendingPair.kitty1.address,
+        abi: lenderAbi as any,
+        calls: [
+          {
+            reference: 'underlyingBalance',
+            methodName: 'underlyingBalance',
+            methodParameters: [userAddress],
+          },
+        ],
+      }
+    )
+  );
+
+  const results = (await multicall.call(contractCallContexts)).results;
+
+  const deprecatedLendingPairBalancesArray: LendingPairBalances[] = [];
+  const balancesMap: LendingPairBalancesMap = new Map();
+
   lendingPairs.forEach((lendingPair) => {
-    contractCallContexts.push({
-      reference: `${lendingPair.uniswapPool}-token0`,
-      contractAddress: lendingPair.token0.address,
-      abi: erc20Abi as any,
-      calls: [
-        {
-          reference: `${lendingPair.token0.address}-balance`,
-          methodName: 'balanceOf',
-          methodParameters: [userAddress],
-        },
-      ],
-      context: { decimals: lendingPair.token0.decimals },
-    });
+    const hexes = [
+      `${lendingPair.token0.address}.balanceOf`,
+      `${lendingPair.token1.address}.balanceOf`,
+      `${lendingPair.kitty0.address}.underlyingBalance`,
+      `${lendingPair.kitty1.address}.underlyingBalance`,
+    ].map((key) => results[key].callsReturnContext[0].returnValues[0].hex);
 
-    contractCallContexts.push({
-      reference: `${lendingPair.uniswapPool}-token1`,
-      contractAddress: lendingPair.token1.address,
-      abi: erc20Abi as any,
-      calls: [
-        {
-          reference: `${lendingPair.token1.address}-balance`,
-          methodName: 'balanceOf',
-          methodParameters: [userAddress],
-        },
-      ],
-      context: { decimals: lendingPair.token1.decimals },
-    });
+    const gns = hexes.map((hex, i) =>
+      GN.fromJSBI(JSBI.BigInt(hex), lendingPair[i % 2 ? 'token1' : 'token0'].decimals, 10)
+    );
 
-    contractCallContexts.push({
-      reference: `${lendingPair.uniswapPool}-kitty0`,
-      contractAddress: lendingPair.kitty0.address,
-      abi: lenderAbi as any,
-      calls: [
-        {
-          reference: `${lendingPair.kitty0.address}-balance`,
-          methodName: 'underlyingBalance',
-          methodParameters: [userAddress],
-        },
-      ],
-      context: { decimals: lendingPair.kitty0.decimals },
-    });
+    // NOTE: If `token0` or `token1` exists in multiple lending pairs, we'll be setting the same value
+    // in the map over and over. This doesn't hurt anything, and as long as we need to generate the old
+    // array-style return value, doing it here is simpler than iterating over the `tokenSet` so as to
+    // set the values only once.
+    balancesMap.set(lendingPair.token0.address, { value: gns[0].toNumber(), gn: gns[0], form: 'raw' });
+    balancesMap.set(lendingPair.token1.address, { value: gns[1].toNumber(), gn: gns[1], form: 'raw' });
+    balancesMap.set(lendingPair.kitty0.address, { value: gns[2].toNumber(), gn: gns[2], form: 'underlying' });
+    balancesMap.set(lendingPair.kitty1.address, { value: gns[3].toNumber(), gn: gns[3], form: 'underlying' });
 
-    contractCallContexts.push({
-      reference: `${lendingPair.uniswapPool}-kitty1`,
-      contractAddress: lendingPair.kitty1.address,
-      abi: lenderAbi as any,
-      calls: [
-        {
-          reference: `${lendingPair.kitty1.address}-balance`,
-          methodName: 'underlyingBalance',
-          methodParameters: [userAddress],
-        },
-      ],
-      context: { decimals: lendingPair.kitty1.decimals },
+    deprecatedLendingPairBalancesArray.push({
+      token0Balance: toImpreciseNumber(BigNumber.from(hexes[0]), lendingPair.token0.decimals),
+      token1Balance: toImpreciseNumber(BigNumber.from(hexes[1]), lendingPair.token1.decimals),
+      kitty0Balance: toImpreciseNumber(BigNumber.from(hexes[2]), lendingPair.token0.decimals),
+      kitty1Balance: toImpreciseNumber(BigNumber.from(hexes[3]), lendingPair.token1.decimals),
     });
   });
 
-  const lendingPairResults = (await multicall.call(contractCallContexts)).results;
-
-  const correspondingLendingPairResults: Map<string, ContractCallReturnContextEntries> = new Map();
-
-  // Convert the results into a map of account address to the results
-  Object.entries(lendingPairResults).forEach(([key, value]) => {
-    const entryAccountAddress = key.split('-')[0];
-    const entryType = key.split('-')[1];
-    const existingValue = correspondingLendingPairResults.get(entryAccountAddress);
-    if (existingValue) {
-      existingValue[entryType] = value;
-      correspondingLendingPairResults.set(entryAccountAddress, existingValue);
-    } else {
-      correspondingLendingPairResults.set(entryAccountAddress, { [entryType]: value });
-    }
-  });
-
-  const lendingPairBalances: LendingPairBalances[] = [];
-
-  correspondingLendingPairResults.forEach((value) => {
-    const { token0, token1, kitty0, kitty1 } = value;
-    const token0ReturnContexts = convertBigNumbersForReturnContexts(token0.callsReturnContext);
-    const token1ReturnContexts = convertBigNumbersForReturnContexts(token1.callsReturnContext);
-    const kitty0ReturnContexts = convertBigNumbersForReturnContexts(kitty0.callsReturnContext);
-    const kitty1ReturnContexts = convertBigNumbersForReturnContexts(kitty1.callsReturnContext);
-    const token0Decimals = token0.originalContractCallContext.context.decimals;
-    const token1Decimals = token1.originalContractCallContext.context.decimals;
-    const token0Balance = toImpreciseNumber(token0ReturnContexts[0].returnValues[0], token0Decimals);
-    const token1Balance = toImpreciseNumber(token1ReturnContexts[0].returnValues[0], token1Decimals);
-    const kitty0Balance = toImpreciseNumber(kitty0ReturnContexts[0].returnValues[0], token0Decimals);
-    const kitty1Balance = toImpreciseNumber(kitty1ReturnContexts[0].returnValues[0], token1Decimals);
-
-    lendingPairBalances.push({
-      token0Balance,
-      token1Balance,
-      kitty0Balance,
-      kitty1Balance,
-    });
-  });
-
-  return lendingPairBalances;
+  return {
+    lendingPairBalances: deprecatedLendingPairBalancesArray,
+    balancesMap,
+  };
 }
 
 /**
@@ -398,7 +384,7 @@ export async function getLendingPairBalances(
 
 export function filterLendingPairsByTokens(lendingPairs: LendingPair[], tokens: Token[]): LendingPair[] {
   return lendingPairs.filter((pair) => {
-    return tokens.some((token) => token.address === pair.token0.address || token.address === pair.token1.address);
+    return tokens.some((token) => pair.token0.equals(token) || pair.token1.equals(token));
   });
 }
 

--- a/earn/src/pages/LendPage.tsx
+++ b/earn/src/pages/LendPage.tsx
@@ -157,7 +157,12 @@ export default function LendPage() {
   useEffect(() => {
     (async () => {
       if (!address) return;
-      const results = await getLendingPairBalances(lendingPairs, address, provider, activeChain.id);
+      const { lendingPairBalances: results } = await getLendingPairBalances(
+        lendingPairs,
+        address,
+        provider,
+        activeChain.id
+      );
       setLendingPairBalances(results);
     })();
   }, [activeChain.id, address, lendingPairs, provider, setLendingPairBalances]);

--- a/earn/src/pages/MarketsPage.tsx
+++ b/earn/src/pages/MarketsPage.tsx
@@ -7,9 +7,8 @@ import { Text } from 'shared/lib/components/common/Typography';
 import { GREY_400, GREY_600 } from 'shared/lib/data/constants/Colors';
 import { useChainDependentState } from 'shared/lib/data/hooks/UseChainDependentState';
 import { Token } from 'shared/lib/data/Token';
-import { getTokenBySymbol } from 'shared/lib/data/TokenData';
 import styled from 'styled-components';
-import { useAccount, useBlockNumber, useProvider } from 'wagmi';
+import { Address, useAccount, useBlockNumber, useProvider } from 'wagmi';
 
 import { ChainContext } from '../App';
 import PendingTxnModal, { PendingTxnModalStatus } from '../components/common/PendingTxnModal';
@@ -19,7 +18,7 @@ import { BorrowerNftBorrower, fetchListOfFuse2BorrowNfts } from '../data/Borrowe
 import { API_PRICE_RELAY_LATEST_URL } from '../data/constants/Values';
 import useAvailablePools from '../data/hooks/UseAvailablePools';
 import { useLendingPairs } from '../data/hooks/UseLendingPairs';
-import { filterLendingPairsByTokens, getLendingPairBalances, LendingPairBalances } from '../data/LendingPair';
+import { filterLendingPairsByTokens, getLendingPairBalances, LendingPairBalancesMap } from '../data/LendingPair';
 import { fetchBorrowerDatas } from '../data/MarginAccount';
 import { PriceRelayLatestResponse } from '../data/PriceRelayResponse';
 import { getProminentColor } from '../util/Colors';
@@ -51,11 +50,6 @@ const HeaderSegmentedControlOption = styled.button.attrs((props: { isActive: boo
   }
 `;
 
-export type TokenQuote = {
-  token: Token;
-  price: number;
-};
-
 export type TokenBalance = {
   token: Token;
   balance: number;
@@ -70,50 +64,40 @@ enum HeaderOptions {
   Borrow,
 }
 
+type TokenSymbol = string;
+type Quote = number;
+
 export default function MarketsPage() {
   const { activeChain } = useContext(ChainContext);
   // MARK: component state
-  const [tokenQuotes, setTokenQuotes] = useChainDependentState<TokenQuote[]>([], activeChain.id);
-  const [lendingPairBalances, setLendingPairBalances] = useChainDependentState<LendingPairBalances[]>(
-    [],
-    activeChain.id
-  );
+  const [tokenQuotes, setTokenQuotes] = useChainDependentState<Map<TokenSymbol, Quote>>(new Map(), activeChain.id);
+  const [balancesMap, setBalancesMap] = useChainDependentState<LendingPairBalancesMap>(new Map(), activeChain.id);
   const [borrowers, setBorrowers] = useChainDependentState<BorrowerNftBorrower[] | null>(null, activeChain.id);
-  const [tokenColors, setTokenColors] = useChainDependentState<Map<string, string>>(new Map(), activeChain.id);
+  const [tokenColors, setTokenColors] = useChainDependentState<Map<Address, string>>(new Map(), activeChain.id);
   const [pendingTxn, setPendingTxn] = useState<SendTransactionResult | null>(null);
   const [isPendingTxnModalOpen, setIsPendingTxnModalOpen] = useState(false);
   const [pendingTxnModalStatus, setPendingTxnModalStatus] = useState<PendingTxnModalStatus | null>(null);
   const [selectedHeaderOption, setSelectedHeaderOption] = useState<HeaderOptions>(HeaderOptions.Supply);
 
+  // MARK: custom hooks
+  const availablePools = useAvailablePools();
   const { lendingPairs } = useLendingPairs();
+
+  // MARK: wagmi hooks
+  const { address: userAddress } = useAccount();
+  const provider = useProvider({ chainId: activeChain.id });
   const { data: blockNumber, refetch } = useBlockNumber({
     chainId: activeChain.id,
   });
 
-  // MARK: wagmi hooks
-  const account = useAccount();
-  const provider = useProvider({ chainId: activeChain.id });
-  const userAddress = account.address;
-
   const uniqueTokens = useMemo(() => {
-    const tokens = new Set<Token>();
+    const tokenSet = new Set<Token>();
     lendingPairs.forEach((pair) => {
-      tokens.add(pair.token0);
-      tokens.add(pair.token1);
+      tokenSet.add(pair.token0);
+      tokenSet.add(pair.token1);
     });
-    return Array.from(tokens.values());
+    return Array.from(tokenSet.values());
   }, [lendingPairs]);
-
-  const uniqueSymbols = useMemo(() => {
-    const symbols = new Set<string>();
-    lendingPairs.forEach((pair) => {
-      symbols.add(pair.token0.symbol.toUpperCase());
-      symbols.add(pair.token1.symbol.toUpperCase());
-    });
-    return Array.from(symbols.values()).join(',');
-  }, [lendingPairs]);
-
-  const availablePools = useAvailablePools();
 
   useEffect(() => {
     (async () => {
@@ -129,61 +113,79 @@ export default function MarketsPage() {
     })();
   }, [pendingTxn, setIsPendingTxnModalOpen, setPendingTxnModalStatus]);
 
+  // MARK: Computing token colors
   useEffect(() => {
     (async () => {
-      const tokenColorMap: Map<string, string> = new Map();
+      // Compute colors for each token logo (local, but still async)
       const colorPromises = uniqueTokens.map((token) => getProminentColor(token.logoURI || ''));
       const colors = await Promise.all(colorPromises);
-      uniqueTokens.forEach((token: Token, index: number) => {
-        tokenColorMap.set(token.address, colors[index]);
-      });
-      setTokenColors(tokenColorMap);
-    })();
-  }, [lendingPairs, setTokenColors, uniqueTokens]);
 
+      // Convert response to the desired Map format
+      const addressToColorMap: Map<Address, string> = new Map();
+      uniqueTokens.forEach((token, index) => addressToColorMap.set(token.address, colors[index]));
+      setTokenColors(addressToColorMap);
+    })();
+  }, [uniqueTokens, setTokenColors]);
+
+  // MARK: Fetching token prices
   useEffect(() => {
-    async function fetch() {
-      // fetch token quotes
+    let mounted = true;
+    (async () => {
+      // Determine set of unique token symbols (tickers)
+      const symbolSet = new Set<string>();
+      lendingPairs.forEach((pair) => {
+        symbolSet.add(pair.token0.symbol);
+        symbolSet.add(pair.token1.symbol);
+      });
+      const uniqueSymbols = Array.from(symbolSet.values());
+
+      // Return early if there's nothing new to fetch
+      if (uniqueSymbols.length === 0 || uniqueSymbols.every((symbol) => tokenQuotes.has(symbol))) {
+        return;
+      }
+
+      // Query API for price data, returning early if request fails
       let quoteDataResponse: AxiosResponse<PriceRelayLatestResponse>;
       try {
-        quoteDataResponse = await axios.get(`${API_PRICE_RELAY_LATEST_URL}?symbols=${uniqueSymbols}`);
+        quoteDataResponse = await axios.get(
+          `${API_PRICE_RELAY_LATEST_URL}?symbols=${uniqueSymbols.join(',').toUpperCase()}`
+        );
       } catch {
         return;
       }
       const prResponse: PriceRelayLatestResponse = quoteDataResponse.data;
-      if (!prResponse) {
-        return;
-      }
-      const tokenQuoteData: TokenQuote[] = Object.entries(prResponse).map(([key, value]) => {
-        return {
-          token: getTokenBySymbol(activeChain.id, key),
-          price: value.price,
-        };
-      });
-      if (tokenQuotes.length === 0) {
-        setTokenQuotes(tokenQuoteData);
-      }
-    }
-    if (uniqueSymbols.length > 0 && tokenQuotes.length === 0) {
-      fetch();
-    }
-  }, [activeChain, tokenQuotes, uniqueSymbols, setTokenQuotes]);
+      if (!prResponse) return;
 
+      // Convert response to the desired Map format
+      const symbolToPriceMap = new Map<TokenSymbol, Quote>();
+      Object.entries(prResponse).forEach(([k, v]) => symbolToPriceMap.set(k, v.price));
+
+      if (mounted) setTokenQuotes(symbolToPriceMap);
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [lendingPairs, tokenQuotes, setTokenQuotes]);
+
+  // MARK: Fetching token balances
   useEffect(() => {
     (async () => {
       if (!userAddress) return;
-      const results = await getLendingPairBalances(lendingPairs, userAddress, provider, activeChain.id);
-      setLendingPairBalances(results);
+      // TODO: I've updated this usage of `getLendingPairBalances` to use the `balancesMap` rather than the old array
+      // return value. Other usages should be updated similarly.
+      const { balancesMap: result } = await getLendingPairBalances(lendingPairs, userAddress, provider, activeChain.id);
+      setBalancesMap(result);
     })();
-  }, [activeChain.id, lendingPairs, provider, setLendingPairBalances, userAddress]);
+  }, [activeChain.id, lendingPairs, provider, setBalancesMap, userAddress]);
 
   // MARK: Fetch margin accounts
   useEffect(() => {
     (async () => {
       if (userAddress === undefined || availablePools.size === 0) return;
-      const fuse2BorrowerNfts = await fetchListOfFuse2BorrowNfts(activeChain.id, provider, userAddress);
 
       const chainId = (await provider.getNetwork()).chainId;
+      const fuse2BorrowerNfts = await fetchListOfFuse2BorrowNfts(chainId, provider, userAddress);
       const borrowerDatas = (
         await fetchBorrowerDatas(
           chainId,
@@ -201,91 +203,17 @@ export default function MarketsPage() {
 
       setBorrowers(borrowerDatas);
     })();
-  }, [activeChain.id, availablePools, provider, userAddress, blockNumber, setBorrowers]);
-
-  const combinedBalances: TokenBalance[] = useMemo(() => {
-    if (tokenQuotes.length === 0) {
-      return [];
-    }
-    let combined = lendingPairs.flatMap((pair, i) => {
-      const token0Quote = tokenQuotes.find((quote) => quote.token.equals(pair.token0));
-      const token1Quote = tokenQuotes.find((quote) => quote.token.equals(pair.token1));
-      const token0Price = token0Quote?.price || 0;
-      const token1Price = token1Quote?.price || 0;
-      const pairName = `${pair.token0.symbol}-${pair.token1.symbol}`;
-      return [
-        {
-          token: pair.token0,
-          balance: lendingPairBalances?.[i]?.token0Balance || 0,
-          balanceUSD: (lendingPairBalances?.[i]?.token0Balance || 0) * token0Price,
-          apy: 0,
-          isKitty: false,
-          pairName,
-        },
-        {
-          token: pair.token1,
-          balance: lendingPairBalances?.[i]?.token1Balance || 0,
-          balanceUSD: (lendingPairBalances?.[i]?.token1Balance || 0) * token1Price,
-          apy: 0,
-          isKitty: false,
-          pairName,
-        },
-        {
-          token: pair.kitty0,
-          balance: lendingPairBalances?.[i]?.kitty0Balance || 0,
-          balanceUSD: (lendingPairBalances?.[i]?.kitty0Balance || 0) * token0Price,
-          apy: pair.kitty0Info.apy,
-          isKitty: true,
-          pairName,
-        },
-        {
-          token: pair.kitty1,
-          balance: lendingPairBalances?.[i]?.kitty1Balance || 0,
-          balanceUSD: (lendingPairBalances?.[i]?.kitty1Balance || 0) * token1Price,
-          apy: pair.kitty1Info.apy,
-          isKitty: true,
-          pairName,
-        },
-      ];
-    });
-    let distinct: TokenBalance[] = [];
-    // We don't want to show duplicate tokens
-    combined.forEach((balance) => {
-      const existing = distinct.find((d) => d.token.equals(balance.token));
-      if (!existing) {
-        distinct.push(balance);
-      }
-    });
-    return distinct;
-  }, [lendingPairBalances, lendingPairs, tokenQuotes]);
-
-  const tokenBalances: TokenBalance[] = useMemo(() => {
-    return Array.from(new Set(combinedBalances.filter((balance) => !balance.isKitty)).values());
-  }, [combinedBalances]);
+  }, [userAddress, availablePools, provider, blockNumber, setBorrowers]);
 
   const supplyRows = useMemo(() => {
     const rows: SupplyTableRow[] = [];
     lendingPairs.forEach((pair) => {
-      const token0Quote = tokenQuotes.find((quote) => quote.token.equals(pair.token0));
-      const token1Quote = tokenQuotes.find((quote) => quote.token.equals(pair.token1));
-      const token0Price = token0Quote?.price || 0;
-      const token1Price = token1Quote?.price || 0;
-      const token0Balance = combinedBalances.find((balance) => balance.token.equals(pair.token0)) || {
-        balance: 0,
-        balanceUSD: 0,
-      };
-      const token1Balance = combinedBalances.find((balance) => balance.token.equals(pair.token1)) || {
-        balance: 0,
-        balanceUSD: 0,
-      };
-      const kitty0Balance = combinedBalances.find((balance) => balance.token.equals(pair.kitty0)) || {
-        balance: 0,
-        balanceUSD: 0,
-      };
-      const kitty1Balance = combinedBalances.find((balance) => balance.token.equals(pair.kitty1)) || {
-        balance: 0,
-        balanceUSD: 0,
-      };
+      const token0Price = tokenQuotes.get(pair.token0.symbol) || 0;
+      const token1Price = tokenQuotes.get(pair.token1.symbol) || 0;
+      const token0Balance = balancesMap.get(pair.token0.address)?.value || 0;
+      const token1Balance = balancesMap.get(pair.token1.address)?.value || 0;
+      const kitty0Balance = balancesMap.get(pair.kitty0.address)?.value || 0;
+      const kitty1Balance = balancesMap.get(pair.kitty1.address)?.value || 0;
       rows.push({
         asset: pair.token0,
         kitty: pair.kitty0,
@@ -294,10 +222,10 @@ export default function MarketsPage() {
         collateralAssets: [pair.token1],
         totalSupply: pair.kitty0Info.inventory,
         totalSupplyUsd: pair.kitty0Info.inventory * token0Price,
-        suppliedBalance: kitty0Balance.balance,
-        suppliedBalanceUsd: kitty0Balance.balanceUSD,
-        suppliableBalance: token0Balance.balance,
-        suppliableBalanceUsd: token0Balance.balanceUSD,
+        suppliedBalance: kitty0Balance,
+        suppliedBalanceUsd: kitty0Balance * token0Price,
+        suppliableBalance: token0Balance,
+        suppliableBalanceUsd: token0Balance * token0Price,
         isOptimized: true,
       });
       rows.push({
@@ -308,30 +236,30 @@ export default function MarketsPage() {
         collateralAssets: [pair.token0],
         totalSupply: pair.kitty1Info.inventory,
         totalSupplyUsd: pair.kitty1Info.inventory * token1Price,
-        suppliedBalance: kitty1Balance.balance,
-        suppliedBalanceUsd: kitty1Balance.balanceUSD,
-        suppliableBalance: token1Balance.balance,
-        suppliableBalanceUsd: token1Balance.balanceUSD,
+        suppliedBalance: kitty1Balance,
+        suppliedBalanceUsd: kitty1Balance * token1Price,
+        suppliableBalance: token1Balance,
+        suppliableBalanceUsd: token1Balance * token1Price,
         isOptimized: true,
       });
     });
     return rows;
-  }, [combinedBalances, lendingPairs, tokenQuotes]);
+  }, [balancesMap, lendingPairs, tokenQuotes]);
 
   const collateralEntries = useMemo(() => {
     const entries: CollateralEntry[] = [];
-    tokenBalances.forEach((tokenBalance) => {
-      if (tokenBalance.balance !== 0) {
-        const matchingPairs = filterLendingPairsByTokens(lendingPairs, [tokenBalance.token]);
+    uniqueTokens.forEach((token) => {
+      const balance = balancesMap.get(token.address)?.value || 0;
+      if (balance > 0) {
         entries.push({
-          asset: tokenBalance.token,
-          balance: tokenBalance.balance,
-          matchingPairs: matchingPairs,
+          asset: token,
+          balance,
+          matchingPairs: filterLendingPairsByTokens(lendingPairs, [token]),
         });
       }
     });
     return entries;
-  }, [lendingPairs, tokenBalances]);
+  }, [uniqueTokens, balancesMap, lendingPairs]);
 
   const borrowEntries = useMemo(() => {
     const borrowable = lendingPairs.reduce((acc: BorrowEntry[], lendingPair) => {

--- a/earn/src/pages/PortfolioPage.tsx
+++ b/earn/src/pages/PortfolioPage.tsx
@@ -207,7 +207,12 @@ export default function PortfolioPage() {
     (async () => {
       // Checking for loading rather than number of pairs as pairs could be empty even if loading is false
       if (!address || isLoading) return;
-      const results = await getLendingPairBalances(lendingPairs, address, provider, activeChain.id);
+      const { lendingPairBalances: results } = await getLendingPairBalances(
+        lendingPairs,
+        address,
+        provider,
+        activeChain.id
+      );
       setLendingPairBalances(results);
     })();
   }, [activeChain.id, address, isLoading, lendingPairs, provider, setLendingPairBalances]);


### PR DESCRIPTION
When the user clicks on an available borrow asset (right side of the `BorrowingWidget`), I noticed that the collateral entries still show a range of LTVs. Similar to how APYs are narrowed down once you make a selection on the left side, LTVs should be narrowed down once you make a selection on the right side.

With the way things were, this would be very hard to do -- the collateral entries were being pre-computed _outside_ of the `BorrowingWidget` component, and to be honest the multitude of arrays (`LendingPairBalances[]`, `combinedBalances`, `tokenBalances`, etc.) were hard to reason about.

So, to prepare for the `BorrowingWidget` updates I want to make, I refactored how we fetch `LendingPairBalances`. It's fully backwards-compatible with existing logic (so I didn't change this stuff on `PortfolioPage` and `LendPage`), but it allows us to use a map instead of searching through an array over and over.

The net result is less code, fewer renders, and fewer network requests (~130 --> ~100). Also, each network request is smaller because I'm making fewer duplicate contract calls in each `multicall`.