### PR TITLE
Compute availablePools locally instead of re-fetching them

### DIFF
--- a/earn/src/data/hooks/UseAvailablePools.ts
+++ b/earn/src/data/hooks/UseAvailablePools.ts
@@ -46,7 +46,7 @@ export default function useAvailablePools() {
           const poolContract = new ethers.Contract(addr, uniswapV3PoolAbi, provider);
           return Promise.all([poolContract.token0(), poolContract.token1(), poolContract.fee()]);
         })
-      );
+      ); // TODO: multicall
 
       const poolInfoMap = new Map<string, UniswapPoolInfo>();
       poolAddresses.forEach((addr, i) => {


### PR DESCRIPTION
This is just an efficiency thing. We have all the data we need from `lendingPairs`, so no need to make more requests to get `availablePools`