### PR TITLE
Use lendingPairs instead of fetching duplicate data in marketInfos

### DIFF
--- a/earn/src/components/lend/modal/UpdateBorrowerModal.tsx
+++ b/earn/src/components/lend/modal/UpdateBorrowerModal.tsx
@@ -8,7 +8,7 @@ import { GREY_700 } from 'shared/lib/data/constants/Colors';
 import styled from 'styled-components';
 
 import { BorrowerNftBorrower } from '../../../data/BorrowerNft';
-import { MarketInfo } from '../../../data/MarketInfo';
+import { LendingPair } from '../../../data/LendingPair';
 import BorrowModalContent from './content/BorrowModalContent';
 import RepayModalContent from './content/RepayModalContent';
 
@@ -50,13 +50,13 @@ const TabButton = styled.button`
 export type UpdateBorrowerModalProps = {
   isOpen: boolean;
   borrower: BorrowerNftBorrower;
-  marketInfo?: MarketInfo;
+  lendingPair?: LendingPair;
   setIsOpen: (isOpen: boolean) => void;
   setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
 };
 
 export default function UpdateBorrowerModal(props: UpdateBorrowerModalProps) {
-  const { isOpen, borrower, marketInfo, setIsOpen, setPendingTxn } = props;
+  const { isOpen, borrower, lendingPair, setIsOpen, setPendingTxn } = props;
   const [confirmationType, setConfirmationType] = useState<ConfirmationType>(ConfirmationType.BORROW);
 
   return (
@@ -86,7 +86,7 @@ export default function UpdateBorrowerModal(props: UpdateBorrowerModalProps) {
               <BorrowModalContent
                 borrower={borrower}
                 setIsOpen={setIsOpen}
-                marketInfo={marketInfo}
+                lendingPair={lendingPair}
                 setPendingTxnResult={setPendingTxn}
               />
             </Tab.Panel>

--- a/earn/src/components/lend/modal/content/BorrowModalContent.tsx
+++ b/earn/src/components/lend/modal/content/BorrowModalContent.tsx
@@ -23,8 +23,8 @@ import { useAccount, useBalance, useContractRead, useContractWrite, usePrepareCo
 import { ChainContext } from '../../../../App';
 import { isHealthy, maxBorrowAndWithdraw } from '../../../../data/BalanceSheet';
 import { BorrowerNftBorrower } from '../../../../data/BorrowerNft';
+import { LendingPair } from '../../../../data/LendingPair';
 import { Liabilities } from '../../../../data/MarginAccount';
-import { MarketInfo } from '../../../../data/MarketInfo';
 import { RateModel, yieldPerSecondToAPR } from '../../../../data/RateModel';
 import HealthBar from '../../../borrow/HealthBar';
 
@@ -169,13 +169,13 @@ function ConfirmButton(props: ConfirmButtonProps) {
 
 export type BorrowModalContentProps = {
   borrower: BorrowerNftBorrower;
-  marketInfo?: MarketInfo;
+  lendingPair?: LendingPair;
   setIsOpen: (isOpen: boolean) => void;
   setPendingTxnResult: (result: SendTransactionResult | null) => void;
 };
 
 export default function BorrowModalContent(props: BorrowModalContentProps) {
-  const { borrower, marketInfo, setIsOpen, setPendingTxnResult } = props;
+  const { borrower, lendingPair, setIsOpen, setPendingTxnResult } = props;
 
   const [additionalBorrowAmountStr, setAdditionalBorrowAmountStr] = useState('');
 
@@ -219,9 +219,15 @@ export default function BorrowModalContent(props: BorrowModalContentProps) {
   const requiredAnte =
     accountEtherBalance !== undefined && accountEtherBalance.lt(ante) ? ante.sub(accountEtherBalance) : GN.zero(18);
 
-  const maxBorrowsBasedOnMarket = isBorrowingToken0
-    ? marketInfo?.lender0AvailableAssets
-    : marketInfo?.lender1AvailableAssets;
+  const lenderInfo = lendingPair?.[isBorrowingToken0 ? 'kitty0Info' : 'kitty1Info'];
+  const inventoryTotal = lenderInfo?.inventory || 0;
+  const inventoryAvailable = inventoryTotal * (lenderInfo?.utilization || 0);
+
+  // Compute updated utilization and apr
+  const inventoryAvailableNew = inventoryAvailable - borrowAmount.toNumber();
+  let utilizationNew = inventoryTotal > 0 ? 1 - inventoryAvailableNew / inventoryTotal : 0;
+  if (inventoryAvailableNew < 0) utilizationNew = 1;
+  const apr = yieldPerSecondToAPR(RateModel.computeYieldPerSecond(utilizationNew)) * 100;
 
   // TODO: use GN
   const maxBorrowsBasedOnHealth = maxBorrowAndWithdraw(
@@ -236,7 +242,7 @@ export default function BorrowModalContent(props: BorrowModalContentProps) {
   )[isBorrowingToken0 ? 0 : 1];
 
   // TODO: use GN
-  const max = Math.min(maxBorrowsBasedOnHealth, maxBorrowsBasedOnMarket?.toNumber() ?? 0);
+  const max = Math.min(maxBorrowsBasedOnHealth, inventoryAvailable);
 
   // Mitigate the case when the number is represented in scientific notation
   const eightyPercentMaxBorrowAmount = GN.fromNumber(max, borrowToken.decimals).recklessMul(80).recklessDiv(100);
@@ -258,21 +264,10 @@ export default function BorrowModalContent(props: BorrowModalContentProps) {
     borrower.token1.decimals
   );
 
-  const availableAssets = isBorrowingToken0 ? marketInfo?.lender0AvailableAssets : marketInfo?.lender1AvailableAssets;
-  const remainingAvailableAssets = availableAssets?.sub(borrowAmount);
-
-  const lenderTotalAssets = isBorrowingToken0 ? marketInfo?.lender0TotalAssets : marketInfo?.lender1TotalAssets;
-  // TODO: use GN
-  const newUtilization =
-    lenderTotalAssets && remainingAvailableAssets && lenderTotalAssets.isGtZero()
-      ? 1 - remainingAvailableAssets.div(lenderTotalAssets).toNumber()
-      : 0;
-  const apr = yieldPerSecondToAPR(RateModel.computeYieldPerSecond(newUtilization)) * 100;
-
   // A user is considered unhealthy if their health is 1 or less
   const isUnhealthy = newHealth <= 1;
   // A user cannot borrow more than the total supply of the market
-  const notEnoughSupply = maxBorrowsBasedOnMarket?.lt(borrowAmount) ?? false;
+  const notEnoughSupply = borrowAmount.toNumber() > inventoryAvailable;
 
   return (
     <>
@@ -338,7 +333,7 @@ export default function BorrowModalContent(props: BorrowModalContentProps) {
         <ConfirmButton
           borrowAmount={borrowAmount}
           borrower={borrower}
-          isLoading={marketInfo === undefined}
+          isLoading={lendingPair === undefined}
           isUnhealthy={isUnhealthy}
           notEnoughSupply={notEnoughSupply}
           requiredAnte={requiredAnte}


### PR DESCRIPTION
Saves a dozen requests on the Markets page and unifies our logic -- basically everything uses the `lendingPairs` array now.

Some day we should refactor `LendingPair` to have `GN`s instead of plain numbers, but today is not that day.