### PR TITLE
Enable reuse of BorrowerNFTs on Markets page

### DIFF
--- a/earn/src/pages/MarketsPage.tsx
+++ b/earn/src/pages/MarketsPage.tsx
@@ -220,8 +220,6 @@ export default function MarketsPage() {
         } as BorrowerNftBorrower;
       });
 
-      console.log(fuse2BorrowerNfts);
-
       setBorrowers(borrowerDatas);
     })();
   }, [userAddress, availablePools, provider, blockNumber, setBorrowers]);

--- a/earn/src/pages/MarketsPage.tsx
+++ b/earn/src/pages/MarketsPage.tsx
@@ -220,6 +220,8 @@ export default function MarketsPage() {
         } as BorrowerNftBorrower;
       });
 
+      console.log(fuse2BorrowerNfts);
+
       setBorrowers(borrowerDatas);
     })();
   }, [userAddress, availablePools, provider, blockNumber, setBorrowers]);


### PR DESCRIPTION
I only did this for normal borrows. Reuse for Uniswap borrows will be a similar, yet separate, PR.