### PR TITLE
Fixing apr showing up as zero

### DIFF
--- a/earn/src/components/lend/BorrowingWidget.tsx
+++ b/earn/src/components/lend/BorrowingWidget.tsx
@@ -256,7 +256,9 @@ export default function BorrowingWidget(props: BorrowingWidgetProps) {
                           ? account.liabilities.amount0
                           : account.liabilities.amount1;
                         const liabilityColor = tokenColors.get(liability.address);
-                        const lendingPair = lendingPairs.find((pair) => pair.uniswapPool === account.uniswapPool);
+                        const lendingPair = lendingPairs.find(
+                          (pair) => pair.uniswapPool.toLowerCase() === account.uniswapPool.toLowerCase()
+                        );
                         const apr =
                           (lendingPair?.[isBorrowingToken0 ? 'kitty0Info' : 'kitty1Info'].borrowAPR || 0) * 100;
                         const roundedApr = Math.round(apr * 100) / 100;


### PR DESCRIPTION
Currently, the borrow tab on the markets page doesn't show APR for active borrows. This PR fixes the issue by correctly comparing Uniswap pools.