### PR TITLE
Fixing division by zero

### DIFF
--- a/earn/src/data/LendingPair.ts
+++ b/earn/src/data/LendingPair.ts
@@ -44,7 +44,7 @@ class KittyInfo {
     public readonly reserveFactor: number
   ) {
     this.availableAssets = totalAssets.sub(totalBorrows);
-    this.utilization = totalBorrows.div(totalAssets).toNumber();
+    this.utilization = totalAssets.isGtZero() ? totalBorrows.div(totalAssets).toNumber() : 0;
     this.lendAPY = borrowAPRToLendAPY(borrowAPR, this.utilization, reserveFactor);
   }
 


### PR DESCRIPTION
Currently, there is a bug that causes pages to crash if there is a lending pair with no supply. This change fixes that by ensuring we don't divide by zero.