### PR TITLE
Handle no lens results

### DIFF
--- a/earn/src/data/BorrowerNft.ts
+++ b/earn/src/data/BorrowerNft.ts
@@ -106,7 +106,9 @@ export async function fetchListOfBorrowerNfts(
       tryAggregate: true,
       multicallCustomContractAddress: MULTICALL_ADDRESS[chainId],
     });
-    const lensResults = (await multicall.call(lensContext)).results['lens'].callsReturnContext;
+    const lensResults = (await multicall.call(lensContext))?.results['lens']?.callsReturnContext;
+    // Return early if there are no results
+    if (!lensResults.length) return [];
     if (lensResults.find((v) => !v.success || !v.decoded)) {
       throw new Error('Multicall error while checking whether Borrowers are in use');
     }

--- a/earn/src/data/BorrowerNft.ts
+++ b/earn/src/data/BorrowerNft.ts
@@ -86,7 +86,10 @@ export async function fetchListOfBorrowerNfts(
   const borrowersInCorrectPool = new Set<Address>();
 
   // Fetch borrowers' in-use status and Uniswap pool, which we'll need for filtering
-  if (filterParams?.includeFreshBorrowers || Boolean(filterParams?.validUniswapPool)) {
+  if (
+    (filterParams?.includeFreshBorrowers || Boolean(filterParams?.validUniswapPool)) &&
+    borrowerManagerSets.size > 0
+  ) {
     const lensContext: ContractCallContext[] = [
       {
         reference: 'lens',
@@ -106,9 +109,7 @@ export async function fetchListOfBorrowerNfts(
       tryAggregate: true,
       multicallCustomContractAddress: MULTICALL_ADDRESS[chainId],
     });
-    const lensResults = (await multicall.call(lensContext))?.results['lens']?.callsReturnContext;
-    // Return early if there are no results
-    if (!lensResults.length) return [];
+    const lensResults = (await multicall.call(lensContext)).results['lens'].callsReturnContext;
     if (lensResults.find((v) => !v.success || !v.decoded)) {
       throw new Error('Multicall error while checking whether Borrowers are in use');
     }


### PR DESCRIPTION
Adding logic to handle and return early the case where there are no lens results when fetching a list of borrower nfts.