### PR TITLE
Make AssetBar more useful by showing more tokens

### DIFF
--- a/earn/src/components/portfolio/AssetBar.tsx
+++ b/earn/src/components/portfolio/AssetBar.tsx
@@ -67,7 +67,7 @@ const StyledMoreIcon = styled(MoreIcon)`
   transform: rotate(90deg);
 `;
 
-const MAX_NUM_CHUNKS = 10;
+const MAX_NUM_CHUNKS = 7;
 
 export type AssetChunkProps = {
   token: Token;

--- a/earn/src/pages/PortfolioPage.tsx
+++ b/earn/src/pages/PortfolioPage.tsx
@@ -350,7 +350,7 @@ export default function PortfolioPage() {
                   <AssetBar
                     balances={combinedBalances}
                     tokenColors={tokenColors}
-                    ignoreBalances={errorLoadingPrices}
+                    ignoreBalances={true}
                     setActiveAsset={(updatedAsset: Token) => {
                       setActiveAsset(updatedAsset);
                     }}


### PR DESCRIPTION
I found myself rarely using the Portfolio page because it almost always showed only a single asset. That was technically correct, percentage-wise, but I wanted to see more. It now shows up to 10 assets, sorted by USD balance, and only slightly varying in size.

Before
<img width="886" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186559/3c935ce1-1b73-4939-9281-32e813966bdd">

After
<img width="886" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186559/eaec416e-7740-4659-a562-f6614b0930d8">
