### PR TITLE
Prevent overflow on portfolio page

### DIFF
--- a/earn/src/components/portfolio/LendingPairPeerCard.tsx
+++ b/earn/src/components/portfolio/LendingPairPeerCard.tsx
@@ -79,7 +79,7 @@ const CardHeader = styled.div`
 
 const CardBody = styled.div`
   display: grid;
-  grid-template-columns: 3fr 1fr 1fr 1fr;
+  grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
@@ -184,11 +184,15 @@ export default function LendingPairPeerCard(props: LendingPairPeerCardProps) {
             <Text size='S' weight='bold' color='rgba(130, 160, 182, 1)'>
               Total Supply
             </Text>
-            <div>
-              <Display size='L' className='inline-block mr-0.5'>
+            <div className='w-full flex whitespace-nowrap overflow-hidden items-baseline justify-center'>
+              <Display
+                size='L'
+                className='overflow-hidden text-ellipsis whitespace-nowrap mr-0.5'
+                title={formatTokenAmount(activeTotalSupply)}
+              >
                 {formatTokenAmount(activeTotalSupply)}
               </Display>
-              <Display size='S' className='inline-block ml-0.5'>
+              <Display size='S' className='ml-0.5'>
                 {activeAsset.symbol}
               </Display>
             </div>


### PR DESCRIPTION
Added some additional styling to prevent overflowing on the lending pair peer card. In addition to adding this, we should probably also investigate a better technique for figuring out how many sigdigs to use.
Before:
<img width="802" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/c5be4d92-3600-4bfa-889d-0cbc03009c82">
After:
<img width="797" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/ac600a1b-597c-4586-933f-887ad1fafb48">
