### PR TITLE
Adding slippage for importing boost positions

### DIFF
--- a/earn/src/components/boost/BurnBoostModal.tsx
+++ b/earn/src/components/boost/BurnBoostModal.tsx
@@ -18,8 +18,6 @@ import { BoostCardInfo } from '../../data/Uniboost';
 import MaxSlippageInput from '../common/MaxSlippageInput';
 
 const SECONDARY_COLOR = '#CCDFED';
-const SLIPPAGE_TOOLTIP_TEXT = `Slippage tolerance is the maximum price difference you are willing to
- accept between the estimated price and the execution price.`;
 
 enum ConfirmButtonState {
   WAITING_FOR_USER,
@@ -136,9 +134,8 @@ export default function BurnBoostModal(props: BurnBoostModalProps) {
   return (
     <Modal isOpen={isOpen} setIsOpen={setIsOpen} title='Burn Boosted Position'>
       <div className='w-full flex flex-col items-center justify-center gap-4'>
-        <div className='w-full flex flex-col gap-1'>
+        <div className='w-full flex flex-col gap-1 mt-6'>
           <MaxSlippageInput
-            tooltipContent={SLIPPAGE_TOOLTIP_TEXT}
             updateMaxSlippage={(value: string) => {
               setSlippagePercentage(value);
             }}

--- a/earn/src/components/boost/ImportBoostWidget.tsx
+++ b/earn/src/components/boost/ImportBoostWidget.tsx
@@ -286,7 +286,8 @@ export default function ImportBoostWidget(props: ImportBoostWidgetProps) {
       .recklessMul(1 + maxSlippage)
       .toBigNumber()
       .add(2);
-    const combinedMaxBorrowAmount = maxBorrowAmount0.add(maxBorrowAmount1.mul(GN.Q(112).toBigNumber()));
+    // 112 bits for maxBorrowAmount0, 112 bits for maxBorrowAmount1
+    const combinedMaxBorrowAmount = maxBorrowAmount0.add(maxBorrowAmount1.shl(112));
     const inner = ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'int24', 'int24', 'uint128', 'uint24', 'uint224'],
       [

--- a/earn/src/components/boost/SlippageWidget.tsx
+++ b/earn/src/components/boost/SlippageWidget.tsx
@@ -1,0 +1,77 @@
+import { useRef, useState } from 'react';
+
+import { RESPONSIVE_BREAKPOINT_XS } from 'shared/lib/data/constants/Breakpoints';
+import { GREY_700, GREY_800 } from 'shared/lib/data/constants/Colors';
+import useClickOutside from 'shared/lib/data/hooks/UseClickOutside';
+import styled from 'styled-components';
+import tw from 'twin.macro';
+
+import { ReactComponent as GearIcon } from '../../assets/svg/gear.svg';
+import MaxSlippageInput from '../common/MaxSlippageInput';
+
+const SvgButtonWrapper = styled.button`
+  ${tw`flex justify-center items-center`}
+  height: max-content;
+  width: max-content;
+  margin-top: auto;
+  margin-bottom: auto;
+  background-color: transparent;
+  border-radius: 8px;
+  padding: 6px;
+  svg {
+    path {
+      stroke: #fff;
+    }
+  }
+
+  &:hover {
+    svg {
+      path {
+        stroke: rgba(255, 255, 255, 0.75);
+      }
+    }
+  }
+`;
+
+const SettingsMenuWrapper = styled.div`
+  ${tw`absolute flex flex-col gap-4`}
+  z-index: 6;
+  background-color: ${GREY_800};
+  border: 1px solid ${GREY_700};
+  border-radius: 8px;
+  min-width: 350px;
+  padding: 16px;
+  top: 42px;
+  right: 0;
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_XS}) {
+    min-width: 300px;
+  }
+`;
+
+export type SlippageWidgetProps = {
+  updateSlippagePercentage: (updatedSlippage: string) => void;
+};
+
+export default function SlippageWidget(props: SlippageWidgetProps) {
+  const { updateSlippagePercentage } = props;
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const settingsMenuRef = useRef(null);
+  useClickOutside(settingsMenuRef, () => {
+    setIsMenuOpen(false);
+  });
+  return (
+    <div className='relative' ref={settingsMenuRef}>
+      <SvgButtonWrapper
+        onClick={() => {
+          setIsMenuOpen(!isMenuOpen);
+        }}
+      >
+        <GearIcon />
+      </SvgButtonWrapper>
+      <SettingsMenuWrapper className={isMenuOpen ? '' : 'invisible'}>
+        <MaxSlippageInput updateMaxSlippage={updateSlippagePercentage} />
+      </SettingsMenuWrapper>
+    </div>
+  );
+}

--- a/earn/src/components/common/MaxSlippageInput.tsx
+++ b/earn/src/components/common/MaxSlippageInput.tsx
@@ -9,6 +9,9 @@ import styled from 'styled-components';
 
 import { RESPONSIVE_BREAKPOINT_XS } from '../../data/constants/Breakpoints';
 
+const SLIPPAGE_TOOLTIP_TEXT = `Slippage tolerance is the maximum price difference you are willing to
+ accept between the estimated price and the execution price.`;
+
 const PREDEFINED_MAX_SLIPPAGE_OPTIONS = [
   { label: 'Low (0.1%)', value: '0.10' },
   { label: 'Mid (0.5%)', value: '0.50' },
@@ -122,12 +125,11 @@ const CustomSlippagePercent = styled.span`
 
 export type MaxSlippageInputProps = {
   updateMaxSlippage: (value: string) => void;
-  tooltipContent: string;
   disabled?: boolean;
 };
 
 export default function MaxSlippageInput(props: MaxSlippageInputProps) {
-  const { updateMaxSlippage, tooltipContent, disabled } = props;
+  const { updateMaxSlippage, disabled } = props;
   const [tempSlippagePercentage, setTempSlippage] = useState('0.10');
   const [slippagePercentage, setSlippage] = useState('0.10');
 
@@ -139,10 +141,10 @@ export default function MaxSlippageInput(props: MaxSlippageInputProps) {
   }, [slippagePercentage]);
 
   return (
-    <div className='w-full flex flex-col gap-y-2 mt-6'>
+    <div className='w-full flex flex-col gap-y-2'>
       <Text size='S' weight='medium' color='rgba(130, 160, 182, 1)' className='flex gap-x-2 mb-1'>
         <Tooltip
-          content={tooltipContent}
+          content={SLIPPAGE_TOOLTIP_TEXT}
           buttonText='Max Slippage'
           buttonSize='S'
           position='bottom-left'

--- a/shared/src/util/Numbers.ts
+++ b/shared/src/util/Numbers.ts
@@ -135,9 +135,7 @@ export function roundUpToNearestN(value: number, n: number): number {
 
 export function formatTokenAmount(amount: number, sigDigs = 4): string {
   //TODO: if we want to support more than one locale, we would need to add more logic here
-  if (amount > 1e34) {
-    return '∞';
-  } else if (amount > 1e13) {
+  if (amount > 1e13) {
     return amount.toExponential(sigDigs - 3);
   } else if (amount > 1e6) {
     return amount.toLocaleString('en-US', {

--- a/shared/src/util/Numbers.ts
+++ b/shared/src/util/Numbers.ts
@@ -135,7 +135,9 @@ export function roundUpToNearestN(value: number, n: number): number {
 
 export function formatTokenAmount(amount: number, sigDigs = 4): string {
   //TODO: if we want to support more than one locale, we would need to add more logic here
-  if (amount > 1e13) {
+  if (amount > 1e34) {
+    return '∞';
+  } else if (amount > 1e13) {
     return amount.toExponential(sigDigs - 3);
   } else if (amount > 1e6) {
     return amount.toLocaleString('en-US', {


### PR DESCRIPTION
The slippage can be adjusted by clicking on the cog which shows the following menu:
<img width="943" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/14307855-3903-4d7b-89a4-62a17a3436e1">
