### PR TITLE
Adding token allocation to the advanced page

### DIFF
--- a/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
+++ b/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
@@ -16,7 +16,7 @@ import { rgb, rgba } from '../../util/Colors';
 const PIE_CHART_HOVER_GROWTH = 1.05;
 
 const PieChartContainer = styled.div`
-  transform: rotate(90deg);
+  transform: rotate(-90deg);
 `;
 
 // MARK: Pie chart setup -------------------------------------------------------------
@@ -93,7 +93,7 @@ const PieChartLabel = styled.div`
 `;
 
 const TokenAllocationBreakdown = styled.div`
-  ${tw`flex flex-row gap-x-12`};
+  ${tw`flex flex-col justify-center gap-y-6`};
   margin-left: 45px;
 
   @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {

--- a/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
+++ b/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
@@ -1,0 +1,413 @@
+import { useState } from 'react';
+
+import { Text } from 'shared/lib/components/common/Typography';
+import { GREY_800 } from 'shared/lib/data/constants/Colors';
+import { GN } from 'shared/lib/data/GoodNumber';
+import styled from 'styled-components';
+import tw from 'twin.macro';
+
+import { sqrtRatioToPrice, sqrtRatioToTick } from '../../data/BalanceSheet';
+import { BorrowerNftBorrower } from '../../data/BorrowerNft';
+import { RESPONSIVE_BREAKPOINT_LG } from '../../data/constants/Breakpoints';
+import { rgb, rgba } from '../../util/Colors';
+
+// MARK: Capturing Mouse Data on container div ---------------------------------------
+
+const PIE_CHART_HOVER_GROWTH = 1.05;
+
+const PieChartContainer = styled.div`
+  transform: rotate(90deg);
+`;
+
+// MARK: Pie chart setup -------------------------------------------------------------
+
+type PieChartSlice = {
+  index: number;
+  percent: number;
+  color: string;
+};
+
+type AllocationPieChartSlice = PieChartSlice & {
+  category: string;
+  metric?: string;
+};
+
+type PieChartSlicePath = {
+  data: string;
+  color: string;
+  percent: number;
+};
+
+function getCoordinatesForPercent(percent: number) {
+  const x = Math.cos(2 * Math.PI * percent);
+  const y = Math.sin(2 * Math.PI * percent);
+  return [x, y];
+}
+
+const TokenAllocationWrapper = styled.div`
+  ${tw`w-full h-full mt-4 pt-2 flex flex-nowrap`}
+  flex-direction: row;
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_LG}) {
+    flex-direction: column;
+  }
+`;
+
+const ExpandingPath = styled.path`
+  transition: transform 0.15s ease-in;
+  :hover {
+    transform: scale(${PIE_CHART_HOVER_GROWTH});
+  }
+`;
+
+const PieChartLabel = styled.div`
+  --width: 145.28px;
+  --height: 145.28px;
+
+  position: absolute;
+  width: var(--width);
+  height: var(--height);
+
+  // set top left corner to be centered in parent
+  left: 50%;
+  top: 50%;
+  // offset top left corner by element width so that text is centered
+  margin-left: calc(var(--width) / -2);
+  margin-top: calc(var(--height) / -2);
+
+  // padding and alignment
+  padding: 4px 15px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  // stuff to make animation work
+  pointer-events: none;
+  transition: all 0.1s linear;
+
+  // colors, borders, text
+  border-radius: calc(var(--height) / 2);
+  background-color: ${GREY_800};
+  color: rgba(255, 255, 255, 1);
+  ${tw`font-bold`};
+`;
+
+const TokenAllocationBreakdown = styled.div`
+  ${tw`flex flex-col justify-center gap-y-12`};
+  margin-left: 45px;
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_LG}) {
+    margin-left: 0;
+    margin-top: 32px;
+  }
+`;
+
+const LabelWrapper = styled.div`
+  ${tw`flex flex-col justify-center items-center`};
+  & div {
+    transition: color 0.15s linear;
+  }
+`;
+
+const TokenLabel = styled.div`
+  width: 80px;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 30px;
+  color: rgba(255, 255, 255, 1);
+  transition: color 0.15s linear;
+
+  &.inactive {
+    color: rgba(255, 255, 255, 0.5);
+  }
+`;
+
+const AllocationSection = styled.div<{ color: string }>`
+  ${tw`w-full flex`};
+  position: relative;
+  white-space: nowrap;
+  padding-left: 24px;
+
+  /* The colored circles to the left of the label */
+  :before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0px;
+
+    width: 8px;
+    height: 8px;
+    aspect-ratio: 1;
+    margin-top: -4px;
+
+    border-radius: 50%;
+    background: ${({ color }) => color};
+    z-index: 5;
+  }
+
+  /* The bar that connects the top circle to a middle circle (doesn't need to extend upwards) */
+  :first-child:after {
+    content: '';
+    position: absolute;
+    top: 63%;
+    left: 3px;
+    width: 2px;
+    height: 37%;
+    background: rgba(255, 255, 255, 0.4);
+    z-index: 2;
+  }
+
+  /* The bar that connects a middle circle to the surrounding circles */
+  :not(:first-child):not(:last-child):after {
+    content: '';
+    position: absolute;
+    top: 0%;
+    left: 3px;
+    width: 2px;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.4);
+    z-index: 2;
+  }
+
+  /* The bar that connects the bottom circle to a middle circle (doesn't need to extend downwards) */
+  :last-child:after {
+    content: '';
+    position: absolute;
+    top: 0%;
+    left: 3px;
+    width: 2px;
+    height: 37%;
+    background: rgba(255, 255, 255, 0.4);
+    z-index: 2;
+  }
+`;
+
+const DashedDivider = styled.div`
+  margin-left: 8px;
+  margin-right: 8px;
+  position: relative;
+  flex-grow: 1;
+  /* The dashed line */
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: calc(50% - 1px);
+    width: 100%;
+    height: 1px;
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.4);
+  }
+`;
+
+export type TokenAllocationPieChartWidgetProps = {
+  borrower: BorrowerNftBorrower;
+  tokenColors: Map<string, string>;
+};
+
+export default function TokenAllocationPieChartWidget(props: TokenAllocationPieChartWidgetProps) {
+  const { borrower, tokenColors } = props;
+  const { token0, token1 } = borrower;
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [currentPercent, setCurrentPercent] = useState('');
+
+  const onMouseEnter = (index: number, percent: string) => {
+    setActiveIndex(index);
+    setCurrentPercent(`${(parseFloat(percent) * 100).toFixed(2)}%`);
+  };
+
+  const onMouseLeave = () => {
+    setActiveIndex(-1);
+    setCurrentPercent('');
+  };
+
+  const price = sqrtRatioToPrice(borrower.sqrtPriceX96, token0.decimals, token1.decimals);
+  const amount0 = borrower.assets.amount0.toNumber();
+  const amount1 = borrower.assets.amount1.toNumber();
+  const [amount0Total, amount1Total] = borrower.assets.amountsAt(sqrtRatioToTick(borrower.sqrtPriceX96));
+  const amount0InTermsOfToken1 = amount0 * price;
+  const amount0UniswapInTermsOfToken1 = (amount0Total - amount0) * price;
+  const amount1Uniswap = amount1Total - amount1;
+  const sliceAmounts = [
+    GN.fromNumber(amount0InTermsOfToken1, token1.decimals),
+    GN.fromNumber(amount0UniswapInTermsOfToken1, token1.decimals),
+    GN.fromNumber(amount1Uniswap, token1.decimals),
+    GN.fromNumber(amount1, token1.decimals),
+  ];
+
+  const totalAssets = sliceAmounts.reduce((a, b) => a.add(b));
+
+  const token0ColorRaw = tokenColors.get(token0.address);
+  const token1ColorRaw = tokenColors.get(token1.address);
+  const token0Color = token0ColorRaw ? rgb(token0ColorRaw) : 'transparent';
+  const token1Color = token1ColorRaw ? rgb(token1ColorRaw) : 'transparent';
+  const uniswap0Color = token0ColorRaw ? rgba(token0ColorRaw, 0.5) : 'transparent';
+  const uniswap1Color = token1ColorRaw ? rgba(token1ColorRaw, 0.5) : 'transparent';
+
+  const slices: AllocationPieChartSlice[] = [
+    {
+      index: 0,
+      percent: totalAssets.isGtZero() ? sliceAmounts[0].div(totalAssets).toNumber() : 0,
+      color: token0Color,
+      category: 'Raw',
+    },
+    {
+      index: 1,
+      percent: totalAssets.isGtZero() ? sliceAmounts[1].div(totalAssets).toNumber() : 0,
+      color: uniswap0Color,
+      category: 'Uniswap',
+    },
+    {
+      index: 2,
+      percent: totalAssets.isGtZero() ? sliceAmounts[2].div(totalAssets).toNumber() : 0,
+      color: uniswap1Color,
+      category: 'Uniswap',
+    },
+    {
+      index: 3,
+      percent: totalAssets.isGtZero() ? sliceAmounts[3].div(totalAssets).toNumber() : 0,
+      color: token1Color,
+      category: 'Raw',
+    },
+  ];
+
+  let cumulativePercent = 0;
+  const paths: PieChartSlicePath[] = slices.map((slice) => {
+    // destructuring assignment sets the two variables at once
+    const [startX, startY] = getCoordinatesForPercent(cumulativePercent);
+    // each slice starts where the last slice ended, so keep a cumulative percent
+    cumulativePercent += slice.percent;
+    const [endX, endY] = getCoordinatesForPercent(cumulativePercent);
+    // if the slice is more than 50%, take the large arc (the long way around)
+    const largeArcFlag = slice.percent > 0.5 ? 1 : 0;
+
+    // create an array and join it just for code readability
+    const pathData = [
+      `M ${startX} ${startY}`, // Move
+      `A 1 1 0 ${largeArcFlag} 1 ${endX} ${endY}`, // Arc
+      `L 0 0`, // Line
+    ].join(' ');
+    return {
+      data: pathData,
+      color: slice.color,
+      percent: slice.percent,
+    };
+  });
+
+  const firstHalfOfSlices = slices.slice(0, slices.length / 2).reverse();
+  const secondHalfOfSlices = slices.slice(slices.length / 2);
+
+  return (
+    <div className='w-full flex flex-col items-start justify-start mb-8'>
+      <TokenAllocationWrapper>
+        <div className='w-[227px] h-[227px] relative'>
+          <PieChartContainer>
+            <svg viewBox='-1 -1 2 2' overflow='visible'>
+              {paths.map((path, index) => {
+                return (
+                  <ExpandingPath
+                    key={index}
+                    d={path.data}
+                    fill={path.color}
+                    onMouseEnter={() => onMouseEnter(index, path.percent.toString())}
+                    onMouseLeave={() => onMouseLeave()}
+                  ></ExpandingPath>
+                );
+              })}
+            </svg>
+          </PieChartContainer>
+          <PieChartLabel>{currentPercent}</PieChartLabel>
+        </div>
+        <TokenAllocationBreakdown>
+          <div className='flex items-center gap-4 w-full'>
+            <TokenLabel className={activeIndex !== -1 && activeIndex >= firstHalfOfSlices.length ? 'inactive' : ''}>
+              {token0.symbol}
+            </TokenLabel>
+            <div className='flex flex-col'>
+              {firstHalfOfSlices.map((slice, index) => {
+                return (
+                  <AllocationSection color={slice.color} key={index}>
+                    <LabelWrapper>
+                      <Text
+                        size='L'
+                        weight='medium'
+                        color={
+                          activeIndex !== -1 && activeIndex !== slice.index
+                            ? 'rgba(255, 255, 255, 0.5)'
+                            : 'rgba(255, 255, 255, 1)'
+                        }
+                      >
+                        {slice.category}
+                      </Text>
+                    </LabelWrapper>
+                    {slice.metric && (
+                      <>
+                        <DashedDivider />
+                        <LabelWrapper>
+                          <Text
+                            size='M'
+                            weight='medium'
+                            color={
+                              activeIndex !== -1 && activeIndex !== slice.index
+                                ? 'rgba(255, 255, 255, 0.5)'
+                                : 'rgba(236, 247, 255, 1)'
+                            }
+                          >
+                            {slice.metric}
+                          </Text>
+                        </LabelWrapper>
+                      </>
+                    )}
+                  </AllocationSection>
+                );
+              })}
+            </div>
+          </div>
+          <div className='flex items-center gap-4'>
+            <TokenLabel className={activeIndex !== -1 && activeIndex < firstHalfOfSlices.length ? 'inactive' : ''}>
+              {token1.symbol}
+            </TokenLabel>
+            <div className='flex flex-col'>
+              {secondHalfOfSlices.map((slice, index) => {
+                return (
+                  <AllocationSection color={slice.color} key={index}>
+                    <LabelWrapper>
+                      <Text
+                        size='L'
+                        weight='medium'
+                        color={
+                          activeIndex !== -1 && activeIndex !== slice.index
+                            ? 'rgba(255, 255, 255, 0.5)'
+                            : 'rgba(255, 255, 255, 1)'
+                        }
+                      >
+                        {slice.category}
+                      </Text>
+                    </LabelWrapper>
+                    {slice.metric && (
+                      <>
+                        <DashedDivider />
+                        <LabelWrapper>
+                          <Text
+                            size='M'
+                            weight='medium'
+                            color={
+                              activeIndex !== -1 && activeIndex !== slice.index
+                                ? 'rgba(255, 255, 255, 0.5)'
+                                : 'rgba(236, 247, 255, 1)'
+                            }
+                          >
+                            {slice.metric}
+                          </Text>
+                        </LabelWrapper>
+                      </>
+                    )}
+                  </AllocationSection>
+                );
+              })}
+            </div>
+          </div>
+        </TokenAllocationBreakdown>
+      </TokenAllocationWrapper>
+    </div>
+  );
+}

--- a/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
+++ b/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { Text } from 'shared/lib/components/common/Typography';
+import { RESPONSIVE_BREAKPOINT_MD } from 'shared/lib/data/constants/Breakpoints';
 import { GREY_800 } from 'shared/lib/data/constants/Colors';
 import { GN } from 'shared/lib/data/GoodNumber';
 import styled from 'styled-components';
@@ -8,7 +9,6 @@ import tw from 'twin.macro';
 
 import { sqrtRatioToPrice, sqrtRatioToTick } from '../../data/BalanceSheet';
 import { BorrowerNftBorrower } from '../../data/BorrowerNft';
-import { RESPONSIVE_BREAKPOINT_LG } from '../../data/constants/Breakpoints';
 import { rgb, rgba } from '../../util/Colors';
 
 // MARK: Capturing Mouse Data on container div ---------------------------------------
@@ -45,10 +45,10 @@ function getCoordinatesForPercent(percent: number) {
 }
 
 const TokenAllocationWrapper = styled.div`
-  ${tw`w-full h-full mt-4 pt-2 flex flex-nowrap`}
+  ${tw`w-full h-full pt-2 flex flex-nowrap`}
   flex-direction: row;
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_LG}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     flex-direction: column;
   }
 `;
@@ -61,8 +61,8 @@ const ExpandingPath = styled.path`
 `;
 
 const PieChartLabel = styled.div`
-  --width: 145.28px;
-  --height: 145.28px;
+  --width: 115.2px;
+  --height: 115.2px;
 
   position: absolute;
   width: var(--width);
@@ -93,10 +93,11 @@ const PieChartLabel = styled.div`
 `;
 
 const TokenAllocationBreakdown = styled.div`
-  ${tw`flex flex-col justify-center gap-y-12`};
+  ${tw`flex flex-row gap-x-12`};
   margin-left: 45px;
 
-  @media (max-width: ${RESPONSIVE_BREAKPOINT_LG}) {
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    ${tw`flex flex-col justify-center gap-y-6`};
     margin-left: 0;
     margin-top: 32px;
   }
@@ -110,9 +111,9 @@ const LabelWrapper = styled.div`
 `;
 
 const TokenLabel = styled.div`
-  width: 80px;
+  width: 90px;
   font-size: 20px;
-  font-weight: 400;
+  font-weight: 300;
   line-height: 30px;
   color: rgba(255, 255, 255, 1);
   transition: color 0.15s linear;
@@ -297,9 +298,9 @@ export default function TokenAllocationPieChartWidget(props: TokenAllocationPieC
   const secondHalfOfSlices = slices.slice(slices.length / 2);
 
   return (
-    <div className='w-full flex flex-col items-start justify-start mb-8'>
+    <div className='w-full flex flex-col items-start justify-start'>
       <TokenAllocationWrapper>
-        <div className='w-[227px] h-[227px] relative'>
+        <div className='w-[180px] h-[180px] relative'>
           <PieChartContainer>
             <svg viewBox='-1 -1 2 2' overflow='visible'>
               {paths.map((path, index) => {
@@ -328,7 +329,7 @@ export default function TokenAllocationPieChartWidget(props: TokenAllocationPieC
                   <AllocationSection color={slice.color} key={index}>
                     <LabelWrapper>
                       <Text
-                        size='L'
+                        size='M'
                         weight='medium'
                         color={
                           activeIndex !== -1 && activeIndex !== slice.index
@@ -362,7 +363,7 @@ export default function TokenAllocationPieChartWidget(props: TokenAllocationPieC
               })}
             </div>
           </div>
-          <div className='flex items-center gap-4'>
+          <div className='flex items-center gap-4 w-full'>
             <TokenLabel className={activeIndex !== -1 && activeIndex < firstHalfOfSlices.length ? 'inactive' : ''}>
               {token1.symbol}
             </TokenLabel>
@@ -372,7 +373,7 @@ export default function TokenAllocationPieChartWidget(props: TokenAllocationPieC
                   <AllocationSection color={slice.color} key={index}>
                     <LabelWrapper>
                       <Text
-                        size='L'
+                        size='M'
                         weight='medium'
                         color={
                           activeIndex !== -1 && activeIndex !== slice.index

--- a/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
+++ b/earn/src/components/advanced/TokenAllocationPieChartWidget.tsx
@@ -149,7 +149,7 @@ const AllocationSection = styled.div<{ color: string }>`
   :first-child:after {
     content: '';
     position: absolute;
-    top: 63%;
+    top: 64%;
     left: 3px;
     width: 2px;
     height: 37%;

--- a/earn/src/components/advanced/TokenAllocationWidget.tsx
+++ b/earn/src/components/advanced/TokenAllocationWidget.tsx
@@ -1,0 +1,67 @@
+import { Text } from 'shared/lib/components/common/Typography';
+import { GREY_700 } from 'shared/lib/data/constants/Colors';
+import styled from 'styled-components';
+
+import { ReactComponent as PieChartIcon } from '../../assets/svg/pie_chart.svg';
+import { sqrtRatioToTick } from '../../data/BalanceSheet';
+import { BorrowerNftBorrower } from '../../data/BorrowerNft';
+import TokenAllocationPieChartWidget from './TokenAllocationPieChartWidget';
+
+const ACCENT_COLOR = 'rgba(130, 160, 182, 1)';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const EmptyStateContainer = styled.div`
+  max-width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: ${GREY_700};
+`;
+
+const StyledPieChartIcon = styled(PieChartIcon)`
+  path {
+    stroke: ${ACCENT_COLOR};
+  }
+`;
+
+export type TokenAllocationWidgetProps = {
+  borrower?: BorrowerNftBorrower;
+  tokenColors: Map<string, string>;
+};
+
+export function TokenAllocationWidget(props: TokenAllocationWidgetProps) {
+  const { borrower, tokenColors } = props;
+
+  if (!borrower) {
+    return null;
+  }
+
+  const currentTick = sqrtRatioToTick(borrower.sqrtPriceX96);
+  const totalAmount = borrower.assets.amountsAt(currentTick).reduce((acc, amount) => {
+    return acc + amount;
+  }, 0);
+
+  return (
+    <Container>
+      <Text size='M'>Token Allocation</Text>
+      {totalAmount === 0 ? (
+        <EmptyStateContainer>
+          <StyledPieChartIcon />
+          <Text size='S' color={ACCENT_COLOR} className='text-center'>
+            A breakdown of your token allocation will appear here.
+          </Text>
+        </EmptyStateContainer>
+      ) : (
+        <TokenAllocationPieChartWidget borrower={borrower} tokenColors={tokenColors} />
+      )}
+    </Container>
+  );
+}

--- a/earn/src/components/advanced/TokenAllocationWidget.tsx
+++ b/earn/src/components/advanced/TokenAllocationWidget.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { Text } from 'shared/lib/components/common/Typography';
 import { GREY_700 } from 'shared/lib/data/constants/Colors';
 import styled from 'styled-components';
@@ -40,19 +42,18 @@ export type TokenAllocationWidgetProps = {
 export function TokenAllocationWidget(props: TokenAllocationWidgetProps) {
   const { borrower, tokenColors } = props;
 
-  if (!borrower) {
-    return null;
-  }
-
-  const currentTick = sqrtRatioToTick(borrower.sqrtPriceX96);
-  const totalAmount = borrower.assets.amountsAt(currentTick).reduce((acc, amount) => {
-    return acc + amount;
-  }, 0);
+  const totalAmount = useMemo(() => {
+    if (borrower === undefined) return 0;
+    const currentTick = sqrtRatioToTick(borrower.sqrtPriceX96);
+    return borrower.assets.amountsAt(currentTick).reduce((acc, amount) => {
+      return acc + amount;
+    }, 0);
+  }, [borrower]);
 
   return (
     <Container>
       <Text size='M'>Token Allocation</Text>
-      {totalAmount === 0 ? (
+      {borrower === undefined || totalAmount === 0 ? (
         <EmptyStateContainer>
           <StyledPieChartIcon />
           <Text size='S' color={ACCENT_COLOR} className='text-center'>


### PR DESCRIPTION
This PR adds a token allocation section to the advanced page to show the relative breakdown of the raw tokens vs Uniswap positions.
Wider screens:
<img width="792" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/eb30aafe-efba-46b3-b6c6-387819701e2f">
Narrower screens:
<img width="287" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/57d00259-0221-4656-ad31-3e8992b74f9d">
Empty state:
<img width="320" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/a86d38e8-1499-4017-845b-c24a184c56d0">
