### PR TITLE
Add oracle cardinality to Monitor tab

### DIFF
--- a/earn/src/components/markets/monitor/StatsTable.tsx
+++ b/earn/src/components/markets/monitor/StatsTable.tsx
@@ -217,6 +217,9 @@ function StatsTableRow(props: StatsTableRowProps) {
         <Display size='XS'>{reserveFactorText}</Display>
       </td>
       <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <Display size='XS'>{pair.slot0Data.observationCardinality}</Display>
+      </td>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
         <div className='flex gap-5 justify-between'>
           <div>
             <div className='flex'>
@@ -321,6 +324,11 @@ export default function StatsTable(props: { rows: StatsTableRowProps[] }) {
                 </Text>
               </th>
               <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <Text size='M' weight='bold'>
+                  Cardinality
+                </Text>
+              </th>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
                 <SortButton onClick={() => requestSort('sortA')}>
                   <Text size='M' weight='bold'>
                     Oracle Guardian
@@ -351,7 +359,7 @@ export default function StatsTable(props: { rows: StatsTableRowProps[] }) {
           </tbody>
           <tfoot>
             <tr>
-              <td className='px-4 py-2' colSpan={7}>
+              <td className='px-4 py-2' colSpan={8}>
                 <Pagination
                   currentPage={currentPage}
                   itemsPerPage={PAGE_SIZE}

--- a/earn/src/data/Slot0.ts
+++ b/earn/src/data/Slot0.ts
@@ -1,0 +1,21 @@
+import { GN } from 'shared/lib/data/GoodNumber';
+
+export type Slot0Data = {
+  sqrtPriceX96: GN;
+  tick: number;
+  observationIndex: number;
+  observationCardinality: number;
+  observationCardinalityNext: number;
+  feeProtocol: number;
+};
+
+export function asSlot0Data(multicallResult: any[]): Slot0Data {
+  return {
+    sqrtPriceX96: GN.fromBigNumber(multicallResult[0], 96, 2),
+    tick: multicallResult[1],
+    observationIndex: multicallResult[2],
+    observationCardinality: multicallResult[3],
+    observationCardinalityNext: multicallResult[4],
+    feeProtocol: multicallResult[5],
+  };
+}


### PR DESCRIPTION
Our oracle needs 60 minutes of data to work right. We require 3 hours of data at pool creation time, but it's possible to stuff the oracle with extra data via wash trading and _shorten the lookback window_. Therefore, I think it's important to surface the actual oracle cardinality on the frontend so users can make even more informed decisions about where to deposit.