### PR TITLE
Adding Uniswap import button to advanced page

### DIFF
--- a/earn/src/components/advanced/UniswapPositionList.tsx
+++ b/earn/src/components/advanced/UniswapPositionList.tsx
@@ -23,6 +23,7 @@ import {
   UniswapPositionCardContainer,
   UniswapPositionCardWrapper,
 } from '../common/UniswapPositionCard';
+import ImportUniswapNFTModal from './modal/ImportUniswapNFTModal';
 import { WithdrawUniswapNFTModal } from './modal/WithdrawUniswapNFTModal';
 
 const ACCENT_COLOR = 'rgba(130, 160, 182, 1)';
@@ -51,12 +52,21 @@ type UniswapPositionCardProps = {
   borrower?: BorrowerNftBorrower;
   uniswapPosition?: UniswapPosition;
   withdrawableUniswapNFTs: Map<number, UniswapNFTPosition>;
+  hasImportableUniswapNFT: boolean;
+  setIsImportingUniswapNFT: (isImporting: boolean) => void;
   setSelectedUniswapPosition: (uniswapPosition: SelectedUniswapPosition | null) => void;
   setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
 };
 
 function UniswapPositionCard(props: UniswapPositionCardProps) {
-  const { borrower, uniswapPosition, withdrawableUniswapNFTs, setSelectedUniswapPosition } = props;
+  const {
+    borrower,
+    uniswapPosition,
+    withdrawableUniswapNFTs,
+    hasImportableUniswapNFT,
+    setIsImportingUniswapNFT,
+    setSelectedUniswapPosition,
+  } = props;
 
   if (!borrower || !uniswapPosition) {
     return (
@@ -64,6 +74,16 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
         <Text size='S' color={ACCENT_COLOR} className='text-center'>
           Empty
         </Text>
+        <div className='flex justify-center items-center mt-4'>
+          <FilledGradientButton
+            size='S'
+            disabled={!hasImportableUniswapNFT}
+            onClick={() => setIsImportingUniswapNFT(true)}
+            fillWidth
+          >
+            Import
+          </FilledGradientButton>
+        </div>
       </UniswapPositionCardWrapper>
     );
   }
@@ -168,13 +188,18 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
 
 export type UniswapPositionListProps = {
   borrower?: BorrowerNftBorrower;
+  importableUniswapNFTPositions: Map<number, UniswapNFTPosition>;
   withdrawableUniswapNFTs: Map<number, UniswapNFTPosition>;
   setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
 };
 
 export function UniswapPositionList(props: UniswapPositionListProps) {
-  const { borrower, withdrawableUniswapNFTs, setPendingTxn } = props;
+  const { borrower, importableUniswapNFTPositions, withdrawableUniswapNFTs, setPendingTxn } = props;
   const [selectedUniswapPosition, setSelectedUniswapPosition] = useState<SelectedUniswapPosition | null>(null);
+  const [isImportingUniswapNFT, setIsImportingUniswapNFT] = useState(false);
+
+  const defaultImportableNFTPosition =
+    importableUniswapNFTPositions.size > 0 ? Array.from(importableUniswapNFTPositions.entries())[0] : null;
 
   return (
     <>
@@ -188,6 +213,8 @@ export function UniswapPositionList(props: UniswapPositionListProps) {
                 borrower={borrower}
                 uniswapPosition={borrower?.assets.uniswapPositions.at(index)}
                 withdrawableUniswapNFTs={withdrawableUniswapNFTs}
+                hasImportableUniswapNFT={importableUniswapNFTPositions.size > 0}
+                setIsImportingUniswapNFT={() => setIsImportingUniswapNFT(true)}
                 setSelectedUniswapPosition={setSelectedUniswapPosition}
                 setPendingTxn={props.setPendingTxn}
               />
@@ -204,6 +231,19 @@ export function UniswapPositionList(props: UniswapPositionListProps) {
           uniswapNFTPosition={selectedUniswapPosition.withdrawableNFT}
           setIsOpen={() => {
             setSelectedUniswapPosition(null);
+          }}
+          setPendingTxn={setPendingTxn}
+        />
+      )}
+      {borrower && importableUniswapNFTPositions.size > 0 && defaultImportableNFTPosition && (
+        <ImportUniswapNFTModal
+          isOpen={isImportingUniswapNFT}
+          borrower={borrower}
+          uniswapNFTPositions={importableUniswapNFTPositions}
+          defaultUniswapNFTPosition={defaultImportableNFTPosition}
+          existingUniswapPositions={borrower.assets.uniswapPositions}
+          setIsOpen={() => {
+            setIsImportingUniswapNFT(false);
           }}
           setPendingTxn={setPendingTxn}
         />

--- a/earn/src/components/advanced/UniswapPositionList.tsx
+++ b/earn/src/components/advanced/UniswapPositionList.tsx
@@ -48,6 +48,45 @@ const PositionList = styled.div`
   justify-content: space-between;
 `;
 
+enum TextAlignment {
+  LEFT = 'text-left',
+  RIGHT = 'text-right',
+}
+
+function TokenInfo(props: { textAlignment: TextAlignment; amount?: string; percentage?: number; symbol: string }) {
+  const { textAlignment, amount, percentage, symbol } = props;
+  return (
+    <div className={`${textAlignment}`}>
+      <Display size='XS' color={ACCENT_COLOR}>
+        {percentage ?? '-'}%
+      </Display>
+      <Display size='S'>{amount ?? '-'}</Display>
+      <Text size='XS'>{symbol}</Text>
+    </div>
+  );
+}
+
+function PriceInfo(props: {
+  textAlignment: TextAlignment;
+  label: string;
+  amount?: string;
+  token0Symbol: string;
+  token1Symbol: string;
+}) {
+  const { textAlignment, label, amount, token0Symbol, token1Symbol } = props;
+  return (
+    <div className={`${textAlignment}`}>
+      <Text size='S' color={ACCENT_COLOR}>
+        {label}
+      </Text>
+      <Display size='S'>{amount ?? '-'}</Display>
+      <Text size='XS'>
+        {token1Symbol} per {token0Symbol}
+      </Text>
+    </div>
+  );
+}
+
 type UniswapPositionCardProps = {
   borrower?: BorrowerNftBorrower;
   uniswapPosition?: UniswapPosition;
@@ -68,21 +107,56 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
     setSelectedUniswapPosition,
   } = props;
 
-  if (!borrower || !uniswapPosition) {
+  if (!borrower) {
     return (
       <UniswapPositionCardWrapper $color={GREY_700}>
         <Text size='S' color={ACCENT_COLOR} className='text-center'>
           Empty
         </Text>
-        <div className='flex justify-center items-center mt-4'>
-          <FilledGradientButton
-            size='S'
-            disabled={!hasImportableUniswapNFT}
-            onClick={() => setIsImportingUniswapNFT(true)}
-            fillWidth
-          >
-            Import
-          </FilledGradientButton>
+      </UniswapPositionCardWrapper>
+    );
+  }
+
+  if (!uniswapPosition) {
+    return (
+      <UniswapPositionCardWrapper $color={GREY_700}>
+        <div className='flex flex-col gap-4'>
+          <div className='flex justify-center items-center'>
+            <TokenPairIcons
+              token0IconPath={borrower.token0.logoURI}
+              token1IconPath={borrower.token1.logoURI}
+              token0AltText={`${borrower.token0.symbol}'s icon`}
+              token1AltText={`${borrower.token1.symbol}'s icon`}
+            />
+          </div>
+          <div className='flex justify-between'>
+            <TokenInfo textAlignment={TextAlignment.LEFT} symbol={borrower.token0.symbol} />
+            <TokenInfo textAlignment={TextAlignment.RIGHT} symbol={borrower.token1.symbol} />
+          </div>
+          <div className='flex justify-between'>
+            <PriceInfo
+              textAlignment={TextAlignment.LEFT}
+              label='Min Price'
+              token0Symbol={borrower.token0.symbol}
+              token1Symbol={borrower.token1.symbol}
+            />
+            <PriceInfo
+              textAlignment={TextAlignment.RIGHT}
+              label='Max Price'
+              token0Symbol={borrower.token0.symbol}
+              token1Symbol={borrower.token1.symbol}
+            />
+          </div>
+          <div className='flex justify-center items-center'>
+            <FilledGradientButton
+              size='S'
+              disabled={!hasImportableUniswapNFT}
+              onClick={() => setIsImportingUniswapNFT(true)}
+              fillWidth
+            >
+              Import
+            </FilledGradientButton>
+          </div>
         </div>
       </UniswapPositionCardWrapper>
     );
@@ -129,40 +203,34 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
           />
         </div>
         <div className='flex justify-between'>
-          <div className='text-left'>
-            <Display size='XS' color={ACCENT_COLOR}>
-              {roundPercentage(amount0Percent, 1)}%
-            </Display>
-            <Display size='S'>{formatTokenAmount(amount0, 5)}</Display>
-            <Text size='XS'>{borrower.token0.symbol}</Text>
-          </div>
-          <div className='text-right'>
-            <Display size='XS' color={ACCENT_COLOR}>
-              {roundPercentage(amount1Percent, 1)}%
-            </Display>
-            <Display size='S'>{formatTokenAmount(amount1, 5)}</Display>
-            <Text size='XS'>{borrower.token1.symbol}</Text>
-          </div>
+          <TokenInfo
+            textAlignment={TextAlignment.LEFT}
+            amount={formatTokenAmount(amount0, 5)}
+            percentage={roundPercentage(amount0Percent, 1)}
+            symbol={borrower.token0.symbol}
+          />
+          <TokenInfo
+            textAlignment={TextAlignment.RIGHT}
+            amount={formatTokenAmount(amount1, 5)}
+            percentage={roundPercentage(amount1Percent, 1)}
+            symbol={borrower.token1.symbol}
+          />
         </div>
         <div className='flex justify-between'>
-          <div className='text-left'>
-            <Text size='S' color={ACCENT_COLOR}>
-              Min Price
-            </Text>
-            <Display size='S'>{formatTokenAmount(minPrice, 5)}</Display>
-            <Text size='XS'>
-              {borrower.token1.symbol} per {borrower.token0.symbol}
-            </Text>
-          </div>
-          <div className='text-right'>
-            <Text size='S' color={ACCENT_COLOR}>
-              Max Price
-            </Text>
-            <Display size='S'>{formatTokenAmount(maxPrice, 5)}</Display>
-            <Text size='XS'>
-              {borrower.token1.symbol} per {borrower.token0.symbol}
-            </Text>
-          </div>
+          <PriceInfo
+            textAlignment={TextAlignment.LEFT}
+            label='Min Price'
+            amount={formatTokenAmount(minPrice, 5)}
+            token0Symbol={borrower.token0.symbol}
+            token1Symbol={borrower.token1.symbol}
+          />
+          <PriceInfo
+            textAlignment={TextAlignment.RIGHT}
+            label='Max Price'
+            amount={formatTokenAmount(maxPrice, 5)}
+            token0Symbol={borrower.token0.symbol}
+            token1Symbol={borrower.token1.symbol}
+          />
         </div>
         <div className='flex justify-between'>
           {isInRange ? <InRangeBadge /> : <OutOfRangeBadge />}

--- a/earn/src/components/advanced/UniswapPositionList.tsx
+++ b/earn/src/components/advanced/UniswapPositionList.tsx
@@ -107,46 +107,10 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
     setSelectedUniswapPosition,
   } = props;
 
-  if (!borrower) {
+  if (!borrower || !uniswapPosition) {
     return (
       <UniswapPositionCardWrapper $color={GREY_700}>
-        <Text size='S' color={ACCENT_COLOR} className='text-center'>
-          Empty
-        </Text>
-      </UniswapPositionCardWrapper>
-    );
-  }
-
-  if (!uniswapPosition) {
-    return (
-      <UniswapPositionCardWrapper $color={GREY_700}>
-        <div className='flex flex-col gap-4'>
-          <div className='flex justify-center items-center'>
-            <TokenPairIcons
-              token0IconPath={borrower.token0.logoURI}
-              token1IconPath={borrower.token1.logoURI}
-              token0AltText={`${borrower.token0.symbol}'s icon`}
-              token1AltText={`${borrower.token1.symbol}'s icon`}
-            />
-          </div>
-          <div className='flex justify-between'>
-            <TokenInfo textAlignment={TextAlignment.LEFT} symbol={borrower.token0.symbol} />
-            <TokenInfo textAlignment={TextAlignment.RIGHT} symbol={borrower.token1.symbol} />
-          </div>
-          <div className='flex justify-between'>
-            <PriceInfo
-              textAlignment={TextAlignment.LEFT}
-              label='Min Price'
-              token0Symbol={borrower.token0.symbol}
-              token1Symbol={borrower.token1.symbol}
-            />
-            <PriceInfo
-              textAlignment={TextAlignment.RIGHT}
-              label='Max Price'
-              token0Symbol={borrower.token0.symbol}
-              token1Symbol={borrower.token1.symbol}
-            />
-          </div>
+        {hasImportableUniswapNFT ? (
           <div className='flex justify-center items-center'>
             <FilledGradientButton
               size='S'
@@ -157,7 +121,11 @@ function UniswapPositionCard(props: UniswapPositionCardProps) {
               Import
             </FilledGradientButton>
           </div>
-        </div>
+        ) : (
+          <Text size='S' color={ACCENT_COLOR} className='text-center'>
+            Empty
+          </Text>
+        )}
       </UniswapPositionCardWrapper>
     );
   }
@@ -281,7 +249,9 @@ export function UniswapPositionList(props: UniswapPositionListProps) {
                 borrower={borrower}
                 uniswapPosition={borrower?.assets.uniswapPositions.at(index)}
                 withdrawableUniswapNFTs={withdrawableUniswapNFTs}
-                hasImportableUniswapNFT={importableUniswapNFTPositions.size > 0}
+                hasImportableUniswapNFT={
+                  importableUniswapNFTPositions.size > 0 && borrower?.assets.uniswapPositions.length === index
+                }
                 setIsImportingUniswapNFT={() => setIsImportingUniswapNFT(true)}
                 setSelectedUniswapPosition={setSelectedUniswapPosition}
                 setPendingTxn={props.setPendingTxn}

--- a/earn/src/components/advanced/modal/ImportUniswapNFTModal.tsx
+++ b/earn/src/components/advanced/modal/ImportUniswapNFTModal.tsx
@@ -1,0 +1,25 @@
+import { SendTransactionResult } from '@wagmi/core';
+import Modal from 'shared/lib/components/common/Modal';
+
+import { BorrowerNftBorrower } from '../../../data/BorrowerNft';
+import { UniswapNFTPosition, UniswapPosition } from '../../../data/Uniswap';
+import { AddUniswapNFTAsCollateralTab } from './tab/AddUniswapNFTAsCollateralTab';
+
+export type ImportUniswapNFTModalProps = {
+  isOpen: boolean;
+  borrower: BorrowerNftBorrower;
+  existingUniswapPositions: readonly UniswapPosition[];
+  uniswapNFTPositions: Map<number, UniswapNFTPosition>;
+  defaultUniswapNFTPosition: [number, UniswapNFTPosition];
+  setIsOpen: (open: boolean) => void;
+  setPendingTxn: (pendingTxn: SendTransactionResult | null) => void;
+};
+
+export default function ImportUniswapNFTModal(props: ImportUniswapNFTModalProps) {
+  const { isOpen, setIsOpen } = props;
+  return (
+    <Modal isOpen={isOpen} title='Import Uniswap NFT Position' setIsOpen={setIsOpen} maxHeight='650px' maxWidth='500px'>
+      <AddUniswapNFTAsCollateralTab {...props} />
+    </Modal>
+  );
+}

--- a/earn/src/pages/AdvancedPage.tsx
+++ b/earn/src/pages/AdvancedPage.tsx
@@ -356,6 +356,7 @@ export default function AdvancedPage() {
             />
             <UniswapPositionList
               borrower={selectedMarginAccount}
+              importableUniswapNFTPositions={filteredNonZeroUniswapNFTPositions}
               withdrawableUniswapNFTs={withdrawableUniswapNFTPositions}
               setPendingTxn={setPendingTxn}
             />


### PR DESCRIPTION
Decided to go with a less bland design for the empty state which shows what the position would look like if imported, but with placeholders. To go along with this, I refactored the code to split the component into smaller pieces to avoid code duplication. Additionally, I reused the content of the existing import modal.

Some other potential ideas I have to further improve this design are:
* Adding further visual distinction between the empty and non-empty cards such as opacity when the card is not hovered.
* Adding a better loading state as it currently uses the old empty state as the loading state (when we don't have the borrower information yet).
* Adding a tooltip somewhere to give more information about what it means to import a uniswap position.
* Refactor the import modal to better align with our other modals as it's content is quite large compared to others on the site.

**Importable:**
<img width="286" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/55be859b-8b40-4ffd-aea9-d4d6d4bf0cdd">
**Not importable:**
<img width="286" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/968d6308-9456-4e70-a451-e39cfc1c56df">
