### PR TITLE
Cleaning up styling of import uniswap modal

### DIFF
--- a/earn/src/components/advanced/modal/tab/AddUniswapNFTAsCollateralTab.tsx
+++ b/earn/src/components/advanced/modal/tab/AddUniswapNFTAsCollateralTab.tsx
@@ -127,7 +127,7 @@ function UniswapNFTPositionButton(props: UniswapNFTPositionButtonProps) {
           token0AltText={`${token0.name}'s Icon`}
           token1AltText={`${token1.name}'s Icon`}
         />
-        <Display size='S' weight='semibold'>
+        <Display size='S' weight='medium'>
           {token0.symbol} / {token1.symbol}
         </Display>
       </div>
@@ -135,7 +135,7 @@ function UniswapNFTPositionButton(props: UniswapNFTPositionButtonProps) {
         <Text size='M' weight='medium' color={SECONDARY_COLOR}>
           Total Liquidity:
         </Text>
-        <Display size='S' weight='semibold'>
+        <Display size='S' weight='medium'>
           {truncateDecimals(liquidityAmount.toString(), 6)} {token1.symbol}
         </Display>
       </div>


### PR DESCRIPTION
Updating the styling to be more inline with the rest of the modals.
**Before:**
<img width="513" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/f66e2f99-dbfa-467e-8bd5-3346bc24bb82">
**After:**
<img width="513" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186604/3003d130-11f4-4ae4-a7f9-465c700115aa">