### PR TITLE
Add liquidate tab to markets page

### DIFF
--- a/earn/src/components/boost/LiquidityChart.tsx
+++ b/earn/src/components/boost/LiquidityChart.tsx
@@ -234,7 +234,6 @@ export default function LiquidityChart(props: LiquidityChartProps) {
       const sqrtRatios = computeLiquidationThresholds(
         info.borrower.assets,
         info.borrower.liabilities,
-        [info.position],
         info.borrower.sqrtPriceX96,
         info.borrower.iv,
         info.borrower.nSigma,

--- a/earn/src/components/markets/liquidate/LiquidateTab.tsx
+++ b/earn/src/components/markets/liquidate/LiquidateTab.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo } from 'react';
+
+import { SendTransactionResult, Provider } from '@wagmi/core';
+import Big from 'big.js';
+import { BigNumber, ethers } from 'ethers';
+import JSBI from 'jsbi';
+import { borrowerLensAbi } from 'shared/lib/abis/BorrowerLens';
+import { factoryAbi } from 'shared/lib/abis/Factory';
+import { ALOE_II_BORROWER_LENS_ADDRESS, ALOE_II_FACTORY_ADDRESS } from 'shared/lib/data/constants/ChainSpecific';
+import { GN, GNFormat } from 'shared/lib/data/GoodNumber';
+import { useChainDependentState } from 'shared/lib/data/hooks/UseChainDependentState';
+import { useContractReads } from 'wagmi';
+
+import { DerivedBorrower } from '../../../data/Borrower';
+import { LendingPair } from '../../../data/LendingPair';
+import { Assets } from '../../../data/MarginAccount';
+import { UniswapPosition } from '../../../data/Uniswap';
+import LiquidateTable, { LiquidateTableRowProps } from './LiquidateTable';
+
+export type LiquidateTabProps = {
+  // Alternatively, could get these 2 from `ChainContext` and `useProvider`, respectively
+  chainId: number;
+  provider: Provider;
+  // Remaining 3 should be passed in for sure though
+  lendingPairs: LendingPair[];
+  tokenQuotes: Map<string, number>;
+  setPendingTxn: (data: SendTransactionResult) => void;
+};
+
+export default function LiquidateTab(props: LiquidateTabProps) {
+  const { chainId, provider, lendingPairs, tokenQuotes, setPendingTxn } = props;
+
+  const [createBorrowerEvents, setCreateBorrowerEvents] = useChainDependentState<ethers.Event[]>([], chainId);
+
+  // Fetch `createBorrowerEvents`
+  useEffect(() => {
+    (async () => {
+      const chainId = (await provider.getNetwork()).chainId;
+      const factory = new ethers.Contract(ALOE_II_FACTORY_ADDRESS[chainId], factoryAbi, provider);
+      const logs = await factory.queryFilter(factory.filters.CreateBorrower(), 'earliest', 'latest');
+
+      setCreateBorrowerEvents(logs.filter((log) => !log.removed && log.args !== undefined));
+    })();
+  }, [provider, lendingPairs, setCreateBorrowerEvents]);
+
+  // Call `getSummary` on each borrower
+  const { data: summaryData } = useContractReads({
+    contracts: createBorrowerEvents.map((ev) => ({
+      chainId,
+      address: ALOE_II_BORROWER_LENS_ADDRESS[chainId],
+      abi: borrowerLensAbi,
+      functionName: 'getSummary',
+      args: [ev.args?.account],
+    })),
+    allowFailure: false,
+    enabled: createBorrowerEvents.length > 0,
+  });
+
+  const lendingPairsForEvents = useMemo(() => {
+    let missing = false;
+    const res = createBorrowerEvents.map((ev) => {
+      const pair = lendingPairs.find((pair) => pair.uniswapPool.toLowerCase() === ev.args!.pool.toLowerCase());
+      if (pair === undefined) missing = true;
+      return pair;
+    });
+
+    if (missing) return undefined;
+    return res as LendingPair[];
+  }, [createBorrowerEvents, lendingPairs]);
+
+  const borrowers = useMemo(() => {
+    if (summaryData === undefined || lendingPairsForEvents === undefined) return undefined;
+    return createBorrowerEvents.map((ev, i) => {
+      const { pool: uniswapPool, owner, account: address } = ev.args!;
+      const summary = summaryData[i] as {
+        balanceEth: BigNumber;
+        balance0: BigNumber;
+        balance1: BigNumber;
+        liabilities0: BigNumber;
+        liabilities1: BigNumber;
+        slot0: BigNumber;
+        liquidity: readonly BigNumber[];
+      };
+
+      const pair = lendingPairsForEvents[i];
+      const liabilities0 = GN.fromBigNumber(summary.liabilities0, pair.token0.decimals);
+      const liabilities1 = GN.fromBigNumber(summary.liabilities1, pair.token1.decimals);
+
+      const slot0 = summary.slot0;
+      const positionTicks: { lower: number; upper: number }[] = [];
+      for (let i = 0; i < 3; i++) {
+        const lower = slot0.shr(24 * i * 2).mask(24);
+        const upper = slot0.shr(24 * i * 2 + 24).mask(24);
+        if (lower.eq(upper)) continue;
+
+        positionTicks.push({ lower: lower.toNumber(), upper: upper.toNumber() });
+      }
+
+      return DerivedBorrower.from({
+        ethBalance: GN.fromBigNumber(summary.balanceEth, 18),
+        assets: new Assets(
+          GN.fromBigNumber(summary.balance0, pair.token0.decimals),
+          GN.fromBigNumber(summary.balance1, pair.token1.decimals),
+          positionTicks.map(
+            (v, i) => ({ ...v, liquidity: JSBI.BigInt(summary.liquidity[i].toString()) } as UniswapPosition)
+          )
+        ),
+        liabilities: {
+          amount0: liabilities0,
+          amount1: liabilities1,
+        },
+        slot0,
+        address,
+        owner,
+        uniswapPool,
+      });
+    });
+  }, [createBorrowerEvents, lendingPairsForEvents, summaryData]);
+
+  const rows = useMemo(() => {
+    if (borrowers === undefined) return [];
+    return borrowers
+      .map((borrower, i) => {
+        if (borrower.ethBalance.isZero()) return undefined;
+        const pair = lendingPairsForEvents![i];
+        const { health } = borrower.health(
+          new Big(pair.oracleData.sqrtPriceX96.toString(GNFormat.INT)),
+          pair.iv,
+          pair.factoryData.nSigma
+        );
+        return {
+          lendingPair: pair,
+          positionValue:
+            borrower.liabilities.amount0.toNumber() * (tokenQuotes.get(pair.token0.symbol) || 0) +
+            borrower.liabilities.amount1.toNumber() * (tokenQuotes.get(pair.token1.symbol) || 0),
+          health,
+          borrower,
+          setPendingTxn,
+        };
+      })
+      .filter((row) => row !== undefined);
+  }, [borrowers, lendingPairsForEvents, tokenQuotes, setPendingTxn]);
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <LiquidateTable rows={rows as LiquidateTableRowProps[]} />
+    </div>
+  );
+}

--- a/earn/src/components/markets/liquidate/LiquidateTable.tsx
+++ b/earn/src/components/markets/liquidate/LiquidateTable.tsx
@@ -1,0 +1,386 @@
+import { useContext, useEffect, useMemo, useState } from 'react';
+
+import { SendTransactionResult } from '@wagmi/core';
+import { BigNumber, ethers } from 'ethers';
+import { borrowerAbi } from 'shared/lib/abis/Borrower';
+import { liquidatorAbi } from 'shared/lib/abis/Liquidator';
+import DownArrow from 'shared/lib/assets/svg/DownArrow';
+import OpenIcon from 'shared/lib/assets/svg/OpenNoPad';
+import UpArrow from 'shared/lib/assets/svg/UpArrow';
+import { FilledGreyButton } from 'shared/lib/components/common/Buttons';
+import Pagination from 'shared/lib/components/common/Pagination';
+import TokenIcons from 'shared/lib/components/common/TokenIcons';
+import { Text, Display } from 'shared/lib/components/common/Typography';
+import { ALOE_II_BORROWER_NFT_ADDRESS, ALOE_II_LIQUIDATOR_ADDRESS } from 'shared/lib/data/constants/ChainSpecific';
+import { GREY_600 } from 'shared/lib/data/constants/Colors';
+import { Q32 } from 'shared/lib/data/constants/Values';
+import { GNFormat } from 'shared/lib/data/GoodNumber';
+import useSortableData from 'shared/lib/data/hooks/UseSortableData';
+import { getEtherscanUrlForChain } from 'shared/lib/util/Chains';
+import { getHealthColor } from 'shared/lib/util/Health';
+import { formatTokenAmountCompact } from 'shared/lib/util/Numbers';
+import styled from 'styled-components';
+import { useAccount, useContractWrite } from 'wagmi';
+
+import { ChainContext } from '../../../App';
+import { Borrower } from '../../../data/Borrower';
+import { ZERO_ADDRESS } from '../../../data/constants/Addresses';
+import { LendingPair } from '../../../data/LendingPair';
+import { truncateAddress } from '../../../util/Addresses';
+
+const PAGE_SIZE = 10;
+const SECONDARY_COLOR = 'rgba(130, 160, 182, 1)';
+const RED_COLOR = 'rgba(234, 87, 87, 0.75)';
+
+function formatAuctionTime(seconds: number) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  const formattedHours = String(hours).padStart(2, '0');
+  const formattedMinutes = String(minutes).padStart(2, '0');
+  const formattedSeconds = (seconds % 60).toFixed(0).padStart(2, '0');
+
+  return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`;
+}
+
+const TableContainer = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  border: 2px solid ${GREY_600};
+  border-radius: 6px;
+`;
+
+const TableHeader = styled.thead`
+  border-bottom: 2px solid ${GREY_600};
+  text-align: start;
+`;
+
+const SortButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const StyledDownArrow = styled(DownArrow)`
+  width: 12px;
+  height: 12px;
+
+  path {
+    stroke: rgba(130, 160, 182, 1);
+    stroke-width: 3px;
+  }
+`;
+
+const StyledUpArrow = styled(UpArrow)`
+  width: 12px;
+  height: 12px;
+
+  path {
+    stroke: rgba(130, 160, 182, 1);
+    stroke-width: 3px;
+  }
+`;
+
+const OpenIconLink = styled.a`
+  svg {
+    path {
+      stroke: ${SECONDARY_COLOR};
+    }
+  }
+`;
+
+type SortArrowProps = {
+  isSorted: boolean;
+  isSortedDesc: boolean;
+};
+
+function SortArrow(props: SortArrowProps) {
+  const { isSorted, isSortedDesc } = props;
+  if (!isSorted) {
+    return null;
+  }
+  if (isSortedDesc) {
+    return <StyledDownArrow />;
+  } else {
+    return <StyledUpArrow />;
+  }
+}
+
+export type LiquidateTableRowProps = {
+  lendingPair: LendingPair;
+  positionValue: number;
+  health: number;
+  borrower: Borrower;
+  setPendingTxn: (data: SendTransactionResult) => void;
+};
+
+function LiquidateTableRow(props: LiquidateTableRowProps) {
+  const { lendingPair: pair, positionValue, health, borrower, setPendingTxn } = props;
+  const { activeChain } = useContext(ChainContext);
+  const { address: userAddress } = useAccount();
+
+  const [, setCurrentTime] = useState(Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setCurrentTime(Date.now()), 1000);
+    if (borrower.warnTime === 0) clearInterval(interval);
+    return () => clearInterval(interval);
+  }, [borrower.warnTime]);
+
+  const { writeAsync: warn } = useContractWrite({
+    address: borrower.address,
+    abi: borrowerAbi,
+    functionName: 'warn',
+    mode: 'recklesslyUnprepared',
+    args: [Q32],
+    chainId: activeChain.id,
+    onSuccess: (data: SendTransactionResult) => setPendingTxn(data),
+  });
+
+  const encodedLiquidateData = useMemo(() => {
+    return ethers.utils.defaultAbiCoder.encode(
+      ['address', 'address', 'address', 'address', 'address', 'address'],
+      [
+        pair.uniswapPool,
+        pair.token0.address,
+        pair.token1.address,
+        pair.kitty0.address,
+        pair.kitty1.address,
+        userAddress ?? ZERO_ADDRESS,
+      ]
+    ) as `0x${string}`;
+  }, [pair, userAddress]);
+
+  const { writeAsync: liquidate } = useContractWrite({
+    address: ALOE_II_LIQUIDATOR_ADDRESS[activeChain.id],
+    abi: liquidatorAbi,
+    functionName: 'liquidate',
+    mode: 'recklesslyUnprepared',
+    args: [borrower.address, encodedLiquidateData, BigNumber.from('10000'), Q32],
+    chainId: activeChain.id,
+    onSuccess: (data: SendTransactionResult) => setPendingTxn(data),
+  });
+
+  const etherscanUrl = getEtherscanUrlForChain(activeChain);
+  const borrowerLink = `${etherscanUrl}/address/${borrower.address}`;
+
+  const isBorrowerNft = borrower.owner === ALOE_II_BORROWER_NFT_ADDRESS[activeChain.id];
+
+  const isHealthy = health > 1;
+  const canBeWarned = !isHealthy && borrower.warnTime === 0;
+  const warnIncentive = borrower.warnIncentive(pair.factoryData.ante);
+
+  const auctionTime = borrower.auctionTime;
+  const auctionCurveValue = borrower.auctionCurveValue;
+  let auctionText = 'Inactive';
+  if (auctionTime !== undefined) {
+    if (auctionTime < 0) {
+      auctionText = `T-${formatAuctionTime(-auctionTime)}`;
+    } else {
+      auctionText = `T+${formatAuctionTime(auctionTime)}`;
+    }
+  }
+  const auctionTextColor = auctionTime === undefined ? SECONDARY_COLOR : 'white';
+  const canBeLiquidated = auctionTime && auctionTime > 0;
+  let incentiveText = `${warnIncentive.toString(GNFormat.DECIMAL)} ETH`;
+  if (auctionTime !== undefined) {
+    const incentive = borrower.nominalLiquidationIncentive(pair.oracleData.sqrtPriceX96, 1.0);
+    if (incentive === undefined) {
+      incentiveText = 'Pending...';
+    } else {
+      // TODO: Either fix `formatTokenAmountCompact` or use different formatter for negatives
+      const incentive0Str = `${formatTokenAmountCompact(incentive.amount0.toNumber())} ${pair.token0.symbol}`;
+      const incentive1Str = `${formatTokenAmountCompact(incentive.amount1.toNumber())} ${pair.token1.symbol}`;
+      const incentiveEthStr = `${incentive.amountEth.toString(GNFormat.DECIMAL)} ETH`;
+      incentiveText = `${incentive0Str}┃${incentive1Str}┃${incentiveEthStr}`;
+    }
+  }
+
+  const healthText = health >= 10 ? '10+ ' : health.toFixed(4);
+  const healthTextColor = getHealthColor(health);
+
+  const lenderLinks = [pair.kitty0.address, pair.kitty1.address].map((addr) => `${etherscanUrl}/address/${addr}`);
+
+  return (
+    <tr className='bg-background hover:bg-row-hover/10'>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <div className='flex items-center gap-2'>
+          <TokenIcons tokens={[pair.token0, pair.token1]} links={lenderLinks} />
+        </div>
+      </td>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <div className='flex items-center gap-2'>
+          <Text size='S'>{truncateAddress(borrower.address, 8)}</Text>
+          <OpenIconLink href={borrowerLink} target='_blank' rel='noreferrer'>
+            <OpenIcon width={12} height={12} />
+          </OpenIconLink>
+        </div>
+        <Display size='XXS' color={SECONDARY_COLOR}>
+          {isBorrowerNft ? 'NFT' : 'Manual'}
+        </Display>
+      </td>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <Display size='XS'>
+          ${positionValue < 1e-4 ? '0.00' : positionValue < 1e4 ? positionValue.toFixed(2) : positionValue.toFixed(0)}
+        </Display>
+      </td>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <Display size='XS'>{incentiveText}</Display>
+        <Display size='XXS' color={SECONDARY_COLOR}>
+          {auctionTime !== undefined ? '(on liquidate)' : '(on warn)'}
+        </Display>
+      </td>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <div className='flex gap-5 justify-between'>
+          <div>
+            <Display size='XS' color={healthTextColor}>
+              {healthText}
+            </Display>
+            <Display size='XXS' color={isHealthy ? SECONDARY_COLOR : RED_COLOR}>
+              {isHealthy ? 'Healthy' : 'Unhealthy'}
+            </Display>
+          </div>
+          {true && (
+            <FilledGreyButton
+              size='S'
+              onClick={() => warn()}
+              disabled={!canBeWarned || userAddress === undefined}
+              backgroundColor={canBeWarned ? RED_COLOR : SECONDARY_COLOR}
+            >
+              {userAddress === undefined ? 'Connect Wallet' : 'Warn'}
+            </FilledGreyButton>
+          )}
+        </div>
+      </td>
+      <td className='px-4 py-2 text-start whitespace-nowrap'>
+        <div className='flex gap-5 justify-between'>
+          <div className='w-[100px]'>
+            <Display size='XS' color={auctionTextColor}>
+              {auctionCurveValue ? (auctionCurveValue * 100).toFixed(2) : '0'}%
+            </Display>
+            <Display size='XXS' color={auctionTextColor}>
+              {auctionText}
+            </Display>
+          </div>
+          {true && (
+            <FilledGreyButton
+              size='S'
+              onClick={() => liquidate()}
+              disabled={!canBeLiquidated || userAddress === undefined}
+            >
+              {userAddress === undefined ? 'Connect Wallet' : 'Liquidate'}
+            </FilledGreyButton>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export default function LiquidateTable(props: { rows: LiquidateTableRowProps[] }) {
+  const { rows } = props;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // workaround to get sort data in the outermost scope
+  const sortableRows = useMemo(() => {
+    return rows.map((row) => ({
+      ...row,
+      // it's the ratio between these two that matters for oracle stability, so that's what we sort by
+      sortA: row.borrower.auctionTime ?? -5 * 60 * 60,
+      // sortB: row.lendingPair.ltv,
+    }));
+  }, [rows]);
+  const { sortedRows, requestSort, sortConfig } = useSortableData(sortableRows, {
+    primaryKey: 'health',
+    secondaryKey: 'positionValue',
+    direction: 'ascending',
+  });
+
+  const pages: LiquidateTableRowProps[][] = useMemo(() => {
+    const pages: LiquidateTableRowProps[][] = [];
+    for (let i = 0; i < sortedRows.length; i += PAGE_SIZE) {
+      pages.push(sortedRows.slice(i, i + PAGE_SIZE));
+    }
+    return pages;
+  }, [sortedRows]);
+  if (pages.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      <TableContainer>
+        <table className='w-full'>
+          <TableHeader>
+            <tr>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <Text size='M' weight='bold'>
+                  Market
+                </Text>
+              </th>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <Text size='M' weight='bold'>
+                  Borrower
+                </Text>
+              </th>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <SortButton onClick={() => requestSort('positionValue')}>
+                  <Text size='M' weight='bold'>
+                    Position Size
+                  </Text>
+                  <SortArrow
+                    isSorted={sortConfig?.primaryKey === 'positionValue' ?? false}
+                    isSortedDesc={sortConfig?.direction === 'descending' ?? false}
+                  />
+                </SortButton>
+              </th>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <Text size='M' weight='bold'>
+                  Incentive
+                </Text>
+              </th>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <SortButton onClick={() => requestSort('health')}>
+                  <Text size='M' weight='bold'>
+                    Health
+                  </Text>
+                  <SortArrow
+                    isSorted={sortConfig?.primaryKey === 'health' ?? false}
+                    isSortedDesc={sortConfig?.direction === 'descending' ?? false}
+                  />
+                </SortButton>
+              </th>
+              <th className='px-4 py-2 text-start whitespace-nowrap'>
+                <SortButton onClick={() => requestSort('sortA')}>
+                  <Text size='M' weight='bold'>
+                    Auction
+                  </Text>
+                  <SortArrow
+                    isSorted={sortConfig?.primaryKey === 'sortA' ?? false}
+                    isSortedDesc={sortConfig?.direction === 'descending' ?? false}
+                  />
+                </SortButton>
+              </th>
+            </tr>
+          </TableHeader>
+          <tbody>
+            {pages[currentPage - 1].map((row) => (
+              <LiquidateTableRow {...row} key={row.borrower.address} />
+            ))}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td className='px-4 py-2' colSpan={6}>
+                <Pagination
+                  currentPage={currentPage}
+                  itemsPerPage={PAGE_SIZE}
+                  totalItems={rows.length}
+                  loading={false}
+                  onPageChange={(page) => setCurrentPage(page)}
+                />
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </TableContainer>
+    </>
+  );
+}

--- a/earn/src/data/Borrower.ts
+++ b/earn/src/data/Borrower.ts
@@ -1,0 +1,118 @@
+import Big from 'big.js';
+import { BigNumber } from 'ethers';
+import { GN } from 'shared/lib/data/GoodNumber';
+import { Address } from 'wagmi';
+
+import { auctionCurve, computeAuctionAmounts, isHealthy } from './BalanceSheet';
+import { ALOE_II_LIQUIDATION_GRACE_PERIOD } from './constants/Values';
+import { Assets } from './MarginAccount';
+
+type Data = {
+  /** The borrower's current Ether balance */
+  readonly ethBalance: GN;
+  /** The borrower's current `Assets` */
+  readonly assets: Assets;
+  /** The borrower's current liabilities */
+  readonly liabilities: { amount0: GN; amount1: GN };
+  /** The current value of `borrower.slot0()` (onchain) */
+  readonly slot0: BigNumber;
+  /** The borrower's address */
+  readonly address: Address;
+  /** The owner of the borrower */
+  readonly owner: Address;
+  /** The Uniswap pool to which the borrower belongs */
+  readonly uniswapPool: Address;
+};
+
+export type Borrower = DerivedBorrower & Data;
+
+export class DerivedBorrower {
+  // NOTE: You can't use parameter destructuring and constructor-inferred instance variables at the same
+  // time. To avoid code duplication, I've split the readonly `Data` type into its own thing, and used
+  // a proxy-based factory pattern.
+  // Oh, and the reason I want parameter destructuring is so that elements of `data` are labelled
+  // whenever creating `Borrower`s.
+  private constructor(private readonly data: Data) {}
+
+  public static from(data: Data): Borrower {
+    const borrower = new DerivedBorrower(data);
+
+    return new Proxy(borrower, {
+      get(target, prop: keyof DerivedBorrower | keyof Data) {
+        if (prop in target) {
+          // First look for property on `Borrower` itself
+          return target[prop as keyof DerivedBorrower];
+        } else if (prop in target.data) {
+          // If it doesn't exist, check inside `data`
+          return target.data[prop as keyof Data];
+        } else {
+          throw new Error(`Property '${String(prop)}' does not exist on Borrower or Borrower.data`);
+        }
+      },
+    }) as Borrower;
+  }
+
+  public get userData() {
+    return this.data.slot0.shr(144).mask(64).toHexString() as `0x${string}`;
+  }
+
+  public get warnTime() {
+    return this.data.slot0.shr(208).mask(40).toNumber();
+  }
+
+  public get auctionTime() {
+    const t = this.warnTime;
+    if (t === 0) return undefined;
+
+    return Date.now() / 1000 - (t + ALOE_II_LIQUIDATION_GRACE_PERIOD);
+  }
+
+  public get auctionCurveValue() {
+    const t = this.auctionTime;
+    if (t === undefined || t < 0) return undefined;
+
+    return auctionCurve(t);
+  }
+
+  public warnIncentive(ante: GN) {
+    return GN.min(this.data.ethBalance, ante.recklessDiv(4));
+  }
+
+  public nominalLiquidationIncentive(sqrtPriceX96: GN, closeFactor: number) {
+    const t = this.auctionTime;
+    if (t === undefined || t < 0) return undefined;
+
+    const { amount0: assets0, amount1: assets1 } = this.data.assets.amountsAtSqrtPrice(sqrtPriceX96);
+    const { out0, out1, repay0, repay1 } = computeAuctionAmounts(
+      sqrtPriceX96,
+      assets0,
+      assets1,
+      this.data.liabilities.amount0,
+      this.data.liabilities.amount1,
+      t,
+      closeFactor
+    );
+
+    return {
+      amount0: out0.sub(repay0),
+      amount1: out1.sub(repay1),
+      amountEth: Math.abs(1 - closeFactor) < Number.EPSILON * 2 ? this.data.ethBalance : GN.zero(18),
+    };
+  }
+
+  // TODO: this is kinda messy and imprecise
+  public health(sqrtPriceX96: Big, iv: number, nSigma: number) {
+    return isHealthy(
+      this.data.assets,
+      {
+        amount0: this.data.liabilities.amount0.toNumber(),
+        amount1: this.data.liabilities.amount1.toNumber(),
+      },
+      sqrtPriceX96,
+      iv,
+      nSigma,
+      this.data.assets.amount0.resolution,
+      this.data.assets.amount1.resolution
+    );
+  }
+}

--- a/earn/src/data/MarginAccount.ts
+++ b/earn/src/data/MarginAccount.ts
@@ -23,7 +23,7 @@ import { Address } from 'wagmi';
 
 import { ContractCallReturnContextEntries, convertBigNumbersForReturnContexts } from '../util/Multicall';
 import { TOPIC0_CREATE_BORROWER_EVENT } from './constants/Signatures';
-import { getAmountsForLiquidity, UniswapPosition } from './Uniswap';
+import { getAmountsForLiquidity, getAmountsForLiquidityGN, UniswapPosition } from './Uniswap';
 
 export class Assets {
   constructor(
@@ -48,6 +48,20 @@ export class Assets {
     }
 
     return [amount0, amount1];
+  }
+
+  amountsAtSqrtPrice(sqrtPriceX96: GN) {
+    let amount0 = this.amount0;
+    let amount1 = this.amount1;
+
+    for (const uniswapPosition of this.uniswapPositions) {
+      const temp = getAmountsForLiquidityGN(uniswapPosition, sqrtPriceX96.toJSBI());
+
+      amount0 = amount0.recklessAdd(temp.amount0.toString(10));
+      amount1 = amount1.recklessAdd(temp.amount1.toString(10));
+    }
+
+    return { amount0, amount1 };
   }
 }
 

--- a/earn/src/data/Uniswap.ts
+++ b/earn/src/data/Uniswap.ts
@@ -108,6 +108,26 @@ function getAmount1ForLiquidity(sqrtRatioAX96: JSBI, sqrtRatioBX96: JSBI, liquid
   return JSBI.divide(numerator, JSBI.BigInt(Q96.toString()));
 }
 
+export function getAmountsForLiquidityGN(position: UniswapPosition, sqrtRatioX96: JSBI) {
+  const sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(position.lower);
+  const sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(position.upper);
+  const liquidity = position.liquidity;
+
+  let amount0 = JSBI.BigInt(0);
+  let amount1 = JSBI.BigInt(0);
+
+  if (JSBI.LE(sqrtRatioX96, sqrtRatioAX96)) {
+    amount0 = getAmount0ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+  } else if (JSBI.LT(sqrtRatioX96, sqrtRatioBX96)) {
+    amount0 = getAmount0ForLiquidity(sqrtRatioX96, sqrtRatioBX96, liquidity);
+    amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioX96, liquidity);
+  } else {
+    amount1 = getAmount1ForLiquidity(sqrtRatioAX96, sqrtRatioBX96, liquidity);
+  }
+
+  return { amount0, amount1 };
+}
+
 export function getAmountsForLiquidity(
   position: UniswapPosition,
   currentTick: number,

--- a/earn/src/data/constants/Values.ts
+++ b/earn/src/data/constants/Values.ts
@@ -1,16 +1,13 @@
-import Big from 'big.js';
 import { BigNumber } from 'ethers';
 import { toBig } from 'shared/lib/util/Numbers';
 import { isDappnet } from 'shared/lib/util/Utils';
 
 export const UINT256_MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 export const BLOCKS_TO_WAIT = 1;
-export const WETH_GAS_RESERVE = new Big('200000000000000000');
 export const DEFAULT_RATIO_CHANGE = '5.0';
 export const RATIO_CHANGE_CUTOFF = 0;
 export const API_URL = 'https://api.aloe.capital';
 export const GAS_ESTIMATION_SCALING = 1.1;
-export const DEFAULT_ADD_LIQUIDITY_SLIPPAGE_PERCENTAGE = 0.5;
 export const Q48 = BigNumber.from('0x1000000000000');
 export const Q96 = BigNumber.from('0x1000000000000000000000000');
 export const BIGQ96 = toBig(Q96);
@@ -18,18 +15,13 @@ export const MAX_UNISWAP_POSITIONS = 3;
 
 export const ALOE_II_LIQUIDATION_INCENTIVE = 20;
 export const ALOE_II_MAX_LEVERAGE = 200;
+export const ALOE_II_LIQUIDATION_GRACE_PERIOD = 5 * 60;
 
 export const API_PRICE_RELAY_LATEST_URL = 'https://api-price.aloe.capital/price-relay/v1/latest';
 export const API_PRICE_RELAY_HISTORICAL_URL = 'https://api-price.aloe.capital/price-relay/v1/historical';
 export const API_PRICE_RELAY_CONSOLIDATED_URL = 'https://api-price.aloe.capital/price-relay/v1/consolidated';
-export const API_REDEEM_REWARD_URL = 'https://api-claim.aloe.capital/v1/claim';
 
 export function primeUrl() {
   // NOTE: trailing `/` is important for .eth domain resolution to work
   return isDappnet() ? 'https://prime.aloe.eth/' : 'https://prime.aloe.capital/';
 }
-
-// NOTE: all lowercase!
-export const ALOE_II_RATE_MODEL_NAMES: { [key: string]: string } = {
-  '0x000000006b66e36407c709ad4808370d963f2aab': 'Rational V0',
-};

--- a/earn/src/pages/MarketsPage.tsx
+++ b/earn/src/pages/MarketsPage.tsx
@@ -17,6 +17,7 @@ import { Address, useAccount, useBlockNumber, useProvider } from 'wagmi';
 import { ChainContext } from '../App';
 import PendingTxnModal, { PendingTxnModalStatus } from '../components/common/PendingTxnModal';
 import BorrowingWidget from '../components/markets/borrow/BorrowingWidget';
+import LiquidateTab from '../components/markets/liquidate/LiquidateTab';
 import InfoTab from '../components/markets/monitor/InfoTab';
 import SupplyTable, { SupplyTableRow } from '../components/markets/supply/SupplyTable';
 import { BorrowerNftBorrower, fetchListOfFuse2BorrowNfts } from '../data/BorrowerNft';
@@ -71,6 +72,7 @@ enum TabOption {
   Supply = 'supply',
   Borrow = 'borrow',
   Monitor = 'monitor',
+  Liquidate = 'liquidate',
 }
 
 type TokenSymbol = string;
@@ -348,6 +350,17 @@ export default function MarketsPage() {
         />
       );
       break;
+    case TabOption.Liquidate:
+      tabContent = (
+        <LiquidateTab
+          chainId={activeChain.id}
+          provider={provider}
+          lendingPairs={lendingPairs}
+          tokenQuotes={tokenQuotes}
+          setPendingTxn={setPendingTxn}
+        />
+      );
+      break;
   }
 
   const totalSupplied = useMemo(() => {
@@ -429,6 +442,14 @@ export default function MarketsPage() {
               aria-selected={selectedTab === TabOption.Monitor}
             >
               Monitor{doesGuardianSenseManipulation ? ' 🚨' : ''}
+            </HeaderSegmentedControlOption>
+            <HeaderSegmentedControlOption
+              isActive={selectedTab === TabOption.Liquidate}
+              onClick={() => setSearchParams({ [SELECTED_TAB_KEY]: TabOption.Liquidate })}
+              role='tab'
+              aria-selected={selectedTab === TabOption.Liquidate}
+            >
+              Liquidate
             </HeaderSegmentedControlOption>
           </div>
           <HeaderDividingLine />

--- a/earn/src/util/Addresses.ts
+++ b/earn/src/util/Addresses.ts
@@ -3,5 +3,5 @@ import { Address } from 'wagmi';
 export function truncateAddress(address: Address, totalLength = 10): string {
   const prefixLength = Math.floor(totalLength / 2);
   const suffixLength = totalLength - prefixLength;
-  return `${address.slice(0, prefixLength)}...${address.slice(-suffixLength)}`;
+  return `${address.slice(0, 2 + prefixLength)}...${address.slice(-suffixLength)}`;
 }

--- a/shared/src/abis/BorrowerLens.ts
+++ b/shared/src/abis/BorrowerLens.ts
@@ -17,6 +17,39 @@ export const borrowerLensAbi = [
   },
   {
     type: 'function',
+    name: 'getSummary',
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        internalType: 'contract Borrower',
+      },
+    ],
+    outputs: [
+      { name: 'balanceEth', type: 'uint256', internalType: 'uint256' },
+      { name: 'balance0', type: 'uint256', internalType: 'uint256' },
+      { name: 'balance1', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'liabilities0',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'liabilities1',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      { name: 'slot0', type: 'uint256', internalType: 'uint256' },
+      {
+        name: 'liquidity',
+        type: 'uint128[]',
+        internalType: 'uint128[]',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'getUniswapPositions',
     inputs: [
       {

--- a/shared/src/abis/Liquidator.ts
+++ b/shared/src/abis/Liquidator.ts
@@ -1,0 +1,80 @@
+export const liquidatorAbi = [
+  { type: 'receive', stateMutability: 'payable' },
+  {
+    type: 'function',
+    name: 'callback',
+    inputs: [
+      { name: 'data', type: 'bytes', internalType: 'bytes' },
+      { name: '', type: 'address', internalType: 'address' },
+      {
+        name: 'amounts',
+        type: 'tuple',
+        internalType: 'struct AuctionAmounts',
+        components: [
+          { name: 'out0', type: 'uint256', internalType: 'uint256' },
+          { name: 'out1', type: 'uint256', internalType: 'uint256' },
+          { name: 'repay0', type: 'uint256', internalType: 'uint256' },
+          { name: 'repay1', type: 'uint256', internalType: 'uint256' },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'canLiquidate',
+    inputs: [
+      {
+        name: 'borrower',
+        type: 'address',
+        internalType: 'contract Borrower',
+      },
+    ],
+    outputs: [
+      { name: '', type: 'bool', internalType: 'bool' },
+      { name: '', type: 'int256', internalType: 'int256' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'canWarn',
+    inputs: [
+      {
+        name: 'borrower',
+        type: 'address',
+        internalType: 'contract Borrower',
+      },
+    ],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'liquidate',
+    inputs: [
+      {
+        name: 'borrower',
+        type: 'address',
+        internalType: 'contract Borrower',
+      },
+      { name: 'data', type: 'bytes', internalType: 'bytes' },
+      { name: 'closeFactor', type: 'uint256', internalType: 'uint256' },
+      { name: 'oracleSeed', type: 'uint40', internalType: 'uint40' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'uniswapV3SwapCallback',
+    inputs: [
+      { name: 'amount0Delta', type: 'int256', internalType: 'int256' },
+      { name: 'amount1Delta', type: 'int256', internalType: 'int256' },
+      { name: '', type: 'bytes', internalType: 'bytes' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const;

--- a/shared/src/data/constants/ChainSpecific.tsx
+++ b/shared/src/data/constants/ChainSpecific.tsx
@@ -122,7 +122,7 @@ export const ALOE_II_FACTORY_ADDRESS: { [chainId: number]: Address } = {
 
 export const ALOE_II_BORROWER_LENS_ADDRESS: { [chainId: number]: Address } = {
   [mainnet.id]: '0x267Fa142FA270F39738443b914FB7d3F95462451',
-  [optimism.id]: '0x267Fa142FA270F39738443b914FB7d3F95462451',
+  [optimism.id]: '0xf8686eaff7106fa6b6337b4fb767557e73299aa0',
   [arbitrum.id]: '0x267Fa142FA270F39738443b914FB7d3F95462451',
   [base.id]: '0x267Fa142FA270F39738443b914FB7d3F95462451',
   [linea.id]: '0x809645F9F667586C49557eA2b68C2F8D64d706CA',
@@ -235,4 +235,12 @@ export const ALOE_II_PERMIT2_MANAGER_ADDRESS: { [chainId: number]: Address } = {
   [base.id]: '0x6BDa468b1d473028938585a04eC3c62dcFF5309B',
   [linea.id]: '0xDd890732Da2C677B987F949c4bBaD831D9B8f468',
   [scroll.id]: '0xDd890732Da2C677B987F949c4bBaD831D9B8f468',
+};
+
+export const ALOE_II_LIQUIDATOR_ADDRESS: { [chainId: number]: Address } = {
+  [mainnet.id]: '0xC8eD78424824Ff7eA3602733909eC57c7d7F7301',
+  [optimism.id]: '0xC8eD78424824Ff7eA3602733909eC57c7d7F7301',
+  [arbitrum.id]: '0xC8eD78424824Ff7eA3602733909eC57c7d7F7301',
+  [base.id]: '0xC8eD78424824Ff7eA3602733909eC57c7d7F7301',
+  [linea.id]: '0xC8eD78424824Ff7eA3602733909eC57c7d7F7301',
 };

--- a/shared/src/util/Numbers.ts
+++ b/shared/src/util/Numbers.ts
@@ -136,6 +136,7 @@ export function roundUpToNearestN(value: number, n: number): number {
 export function formatTokenAmount(amount: number, sigDigs = 4): string {
   const lengthBeforeDecimal = Math.floor(amount).toString().length;
   const adjustedSigDigs = Math.max(sigDigs, lengthBeforeDecimal);
+  // TODO: negative numbers are always expressed in scientific notation because of our conditionals here
   //TODO: if we want to support more than one locale, we would need to add more logic here
   if (amount > 1e13) {
     return amount.toExponential(sigDigs - 3);


### PR DESCRIPTION
_todo_
- [x] Deploy new `BorrowerLens` to chains besides Optimism
- [x] Figure out why clicking the Liquidate tab causes page to jump to top if you had previously scrolled (other tabs don't do this)

<img width="1259" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186559/79885017-fdef-4c94-b731-87651f40f28a">
<img width="1259" alt="image" src="https://github.com/aloelabs/aloe-frontend/assets/17186559/ab6f4870-015d-4faa-b5ec-c7c984b44330">
