### PR TITLE
Add recover modal to help users deal with bad debt

### DIFF
--- a/earn/src/components/common/AddressDropdown.tsx
+++ b/earn/src/components/common/AddressDropdown.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useRef, useState } from 'react';
+
+import DropdownArrowDown from 'shared/lib/assets/svg/DropdownArrowDown';
+import DropdownArrowUp from 'shared/lib/assets/svg/DropdownArrowUp';
+import { Text } from 'shared/lib/components/common/Typography';
+import { GREY_800 } from 'shared/lib/data/constants/Colors';
+import styled from 'styled-components';
+import { Address } from 'viem';
+
+const DEFAULT_BACKGROUND_COLOR = GREY_800;
+const DEFAULT_BACKGROUND_COLOR_HOVER = 'rgb(18, 32, 41)';
+const DROPDOWN_HEADER_BORDER_COLOR = 'rgba(34, 54, 69, 1)';
+const DROPDOWN_LIST_SHADOW_COLOR = 'rgba(0, 0, 0, 0.12)';
+const DROPDOWN_PADDING_SIZES = {
+  S: '8px 38px 8px 12px',
+  M: '10px 40px 10px 16px',
+  L: '12px 42px 12px 20px',
+};
+
+const DropdownWrapper = styled.div.attrs((props: { compact?: boolean }) => props)`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  justify-content: space-evenly;
+  position: relative;
+  overflow: visible;
+  width: ${(props) => (props.compact ? 'max-content' : '100%')};
+`;
+
+const DropdownHeader = styled.button.attrs(
+  (props: { size: 'S' | 'M' | 'L'; backgroundColor?: string; compact?: boolean }) => props
+)`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${(props) => DROPDOWN_PADDING_SIZES[props.size]};
+  width: ${(props) => (props.compact ? 'max-content' : '100%')};
+  background-color: ${(props) => props.backgroundColor || DEFAULT_BACKGROUND_COLOR};
+  border: 1px solid ${DROPDOWN_HEADER_BORDER_COLOR};
+  border-radius: 8px;
+  cursor: pointer;
+  &.active {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+`;
+
+const DropdownList = styled.div.attrs((props: { backgroundColor?: string }) => props)`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  min-width: 100%;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  z-index: 1;
+  background-color: ${(props) => props.backgroundColor || DEFAULT_BACKGROUND_COLOR};
+  border: 1px solid ${DROPDOWN_HEADER_BORDER_COLOR};
+  border-top: 0;
+  box-shadow: 0px 4px 8px ${DROPDOWN_LIST_SHADOW_COLOR};
+`;
+
+const DropdownListItem = styled.button.attrs(
+  (props: { size: 'S' | 'M' | 'L'; backgroundColor?: string; backgroundColorHover?: string }) => props
+)`
+  text-align: start;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  white-space: nowrap;
+  width: 100%;
+  background-color: ${(props) => props.backgroundColor || DEFAULT_BACKGROUND_COLOR};
+  padding: ${(props) => DROPDOWN_PADDING_SIZES[props.size]};
+  cursor: pointer;
+
+  &:last-child {
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+  }
+  &:hover {
+    background-color: ${(props) => props.backgroundColorHover || DEFAULT_BACKGROUND_COLOR_HOVER};
+  }
+`;
+
+export type AddressDropdownProps = {
+  options: Address[];
+  selectedOption: Address;
+  onSelect: (option: Address) => void;
+  size: 'S' | 'M' | 'L';
+  backgroundColor?: string;
+  backgroundColorHover?: string;
+  compact?: boolean;
+};
+
+export default function AddressDropdown(props: AddressDropdownProps) {
+  const { options, selectedOption, onSelect, size, backgroundColor, backgroundColorHover, compact } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  });
+
+  return (
+    <DropdownWrapper ref={dropdownRef} compact={compact}>
+      <DropdownHeader
+        onClick={() => setIsOpen(!isOpen)}
+        size={size}
+        backgroundColor={backgroundColor}
+        compact={compact}
+        className={isOpen ? 'active' : ''}
+      >
+        <div className='flex items-center gap-2'>
+          <Text size='S' weight='medium'>
+            {selectedOption}
+          </Text>
+        </div>
+        {isOpen ? (
+          <DropdownArrowUp className='w-5 absolute right-3' />
+        ) : (
+          <DropdownArrowDown className='w-5 absolute right-3' />
+        )}
+      </DropdownHeader>
+      {isOpen && (
+        <DropdownList backgroundColor={backgroundColor}>
+          {options.map((option) => (
+            <DropdownListItem
+              key={option}
+              onClick={() => {
+                onSelect(option);
+                setIsOpen(false);
+              }}
+              size={size}
+              backgroundColor={backgroundColor}
+              backgroundColorHover={backgroundColorHover}
+            >
+              <div className='flex items-center gap-2'>
+                <Text size='S' weight='medium'>
+                  {option}
+                </Text>
+              </div>
+            </DropdownListItem>
+          ))}
+        </DropdownList>
+      )}
+    </DropdownWrapper>
+  );
+}

--- a/earn/src/components/markets/modal/RecoverModal.tsx
+++ b/earn/src/components/markets/modal/RecoverModal.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+
+import { type WriteContractReturnType } from '@wagmi/core';
+import { badDebtProcessorAbi } from 'shared/lib/abis/BadDebtProcessor';
+import { lenderAbi } from 'shared/lib/abis/Lender';
+import { FilledStylizedButton } from 'shared/lib/components/common/Buttons';
+import Modal from 'shared/lib/components/common/Modal';
+import { Text } from 'shared/lib/components/common/Typography';
+import { Token } from 'shared/lib/data/Token';
+import useChain from 'shared/lib/hooks/UseChain';
+import { PermitState, usePermit } from 'shared/lib/hooks/UsePermit';
+import { Address, Hex } from 'viem';
+import { base } from 'viem/chains';
+import { useReadContract, useSimulateContract, useWriteContract } from 'wagmi';
+
+import AddressDropdown from '../../common/AddressDropdown';
+import { SupplyTableRow } from '../supply/SupplyTable';
+
+const SECONDARY_COLOR = 'rgba(130, 160, 182, 1)';
+
+export const ALOE_II_BAD_DEBT_LENDERS: { [chainId: number]: string[] } = {
+  [base.id]: ['0x25D3C4a59AC57D725dBB4a4EB42BADcF20F37bcD'.toLowerCase()],
+};
+
+const ALOE_II_BAD_DEBT_PROCESSOR: { [chainId: number]: Address } = {
+  [base.id]: '0x8B8eD03dcDa4A4582FD3D395a84F77A334335416',
+};
+
+const OPTIONS: { [chainId: number]: { borrower: Address; flashPool: Address }[] } = {
+  [base.id]: [
+    {
+      borrower: '0xC7Cdda63Bf761c663FD7058739be847b422aA5A2',
+      flashPool: '0x20E068D76f9E90b90604500B84c7e19dCB923e7e',
+    },
+  ],
+};
+
+enum ConfirmButtonState {
+  READY_TO_SIGN,
+  READY_TO_REDEEM,
+  WAITING_FOR_TRANSACTION,
+  WAITING_FOR_USER,
+  LOADING,
+  DISABLED,
+}
+
+const PERMIT_STATE_TO_BUTTON_STATE = {
+  [PermitState.FETCHING_DATA]: ConfirmButtonState.LOADING,
+  [PermitState.READY_TO_SIGN]: ConfirmButtonState.READY_TO_SIGN,
+  [PermitState.ASKING_USER_TO_SIGN]: ConfirmButtonState.WAITING_FOR_USER,
+  [PermitState.ERROR]: ConfirmButtonState.DISABLED,
+  [PermitState.DONE]: ConfirmButtonState.DISABLED,
+  [PermitState.DISABLED]: ConfirmButtonState.DISABLED,
+};
+
+function getConfirmButton(state: ConfirmButtonState, token: Token): { text: string; enabled: boolean } {
+  switch (state) {
+    case ConfirmButtonState.READY_TO_SIGN:
+      return { text: `Permit Recovery`, enabled: true };
+    case ConfirmButtonState.READY_TO_REDEEM:
+      return { text: 'Confirm', enabled: true };
+    case ConfirmButtonState.WAITING_FOR_TRANSACTION:
+      return { text: 'Pending', enabled: false };
+    case ConfirmButtonState.WAITING_FOR_USER:
+      return { text: 'Check Wallet', enabled: false };
+    case ConfirmButtonState.LOADING:
+      return { text: 'Loading', enabled: false };
+    case ConfirmButtonState.DISABLED:
+    default:
+      return { text: 'Confirm', enabled: false };
+  }
+}
+
+export default function RecoverModal({
+  isOpen,
+  selectedRow,
+  userAddress,
+  setIsOpen,
+  setPendingTxn,
+}: {
+  isOpen: boolean;
+  selectedRow: SupplyTableRow;
+  userAddress: Address;
+  setIsOpen: (isOpen: boolean) => void;
+  setPendingTxn: (pendingTxn: WriteContractReturnType | null) => void;
+}) {
+  const activeChain = useChain();
+  const [selectedOption, setSelectedOption] = useState(OPTIONS[activeChain.id][0]);
+
+  const { data: balanceResult } = useReadContract({
+    abi: lenderAbi,
+    address: selectedRow.kitty.address,
+    functionName: 'balanceOf',
+    args: [userAddress],
+    query: {
+      enabled: isOpen,
+      refetchInterval: 3_000,
+      refetchIntervalInBackground: false,
+    },
+  });
+
+  const {
+    state: permitState,
+    action: permitAction,
+    result: permitResult,
+  } = usePermit(
+    activeChain.id,
+    selectedRow.kitty.address,
+    userAddress,
+    ALOE_II_BAD_DEBT_PROCESSOR[activeChain.id],
+    balanceResult?.toString(10) ?? '0',
+    isOpen && balanceResult !== undefined
+  );
+
+  const {
+    data: configRecover,
+    error: errorRecover,
+    isLoading: loadingRecover,
+  } = useSimulateContract({
+    chainId: activeChain.id,
+    abi: badDebtProcessorAbi,
+    address: ALOE_II_BAD_DEBT_PROCESSOR[activeChain.id],
+    functionName: 'processWithPermit',
+    args: [
+      selectedRow.kitty.address,
+      selectedOption.borrower,
+      selectedOption.flashPool,
+      10n,
+      balanceResult ?? 0n,
+      BigInt(permitResult.deadline),
+      permitResult.signature?.v ?? 0,
+      (permitResult.signature?.r ?? '0x0') as Hex,
+      (permitResult.signature?.s ?? '0x0') as Hex,
+    ],
+    query: { enabled: isOpen && permitResult.signature !== undefined },
+  });
+
+  const { writeContract: recover, data: txn, isPending, reset: resetTxn } = useWriteContract();
+
+  useEffect(() => {
+    if (txn === undefined) return;
+    setPendingTxn(txn);
+    resetTxn();
+    setIsOpen(false);
+  }, [txn, setPendingTxn, resetTxn, setIsOpen]);
+
+  let confirmButtonState: ConfirmButtonState;
+  if (isPending || txn) {
+    confirmButtonState = ConfirmButtonState.WAITING_FOR_TRANSACTION;
+  } else if (configRecover !== undefined) {
+    confirmButtonState = ConfirmButtonState.READY_TO_REDEEM;
+  } else if (balanceResult === undefined || loadingRecover) {
+    confirmButtonState = ConfirmButtonState.LOADING;
+  } else {
+    confirmButtonState = PERMIT_STATE_TO_BUTTON_STATE[permitState];
+  }
+  const confirmButton = getConfirmButton(confirmButtonState, selectedRow.asset);
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} title='Recover'>
+      <div className='w-full flex flex-col gap-4'>
+        <Text size='M' weight='bold'>
+          Select a borrower with bad debt:
+        </Text>
+        <AddressDropdown
+          size='M'
+          options={OPTIONS[activeChain.id].map((option) => option.borrower)}
+          selectedOption={selectedOption.borrower}
+          onSelect={(borrowerAddress) =>
+            setSelectedOption(OPTIONS[activeChain.id].find((option) => option.borrower === borrowerAddress)!)
+          }
+        />
+        <div className='flex flex-col gap-1 w-full'>
+          <Text size='M' weight='bold'>
+            Explanation
+          </Text>
+          <Text size='XS' color={SECONDARY_COLOR} className='overflow-hidden text-ellipsis'>
+            Standard withdrawals are impossible right now due to bad debt. You can, however, get a portion of your funds
+            back by simultaenously withdrawing and liquidating the problematic borrower. Note that you'll receive a
+            combination of {selectedRow.collateralAssets[0].symbol} and {selectedRow.collateralAssets[1].symbol} instead
+            of just {selectedRow.kitty.underlying.symbol}. This method is experimental, so we encourage you to triple
+            check the transaction simulation results in a wallet like Rabby. Please reach out in Discord if you have
+            questions.
+          </Text>
+        </div>
+        <FilledStylizedButton
+          size='M'
+          onClick={() => {
+            if (permitAction) permitAction();
+            else if (configRecover) {
+              recover(configRecover.request);
+            }
+          }}
+          fillWidth={true}
+          disabled={!confirmButton.enabled}
+        >
+          {confirmButton.text}
+        </FilledStylizedButton>
+      </div>
+      {errorRecover && (
+        <Text size='XS' color={'rgba(234, 87, 87, 0.75)'} className='w-full mt-2'>
+          {errorRecover.message}
+        </Text>
+      )}
+    </Modal>
+  );
+}

--- a/earn/src/components/markets/modal/WithdrawModal.tsx
+++ b/earn/src/components/markets/modal/WithdrawModal.tsx
@@ -130,8 +130,6 @@ export default function WithdrawModal(props: WithdrawModalProps) {
     GNFormat.DECIMAL
   );
 
-  // TODO: add a message if the use is not able to withdraw everything which explains why
-
   return (
     <Modal isOpen={isOpen} setIsOpen={setIsOpen} title='Withdraw'>
       <div className='w-full flex flex-col gap-4'>

--- a/earn/src/components/markets/supply/SupplyTable.tsx
+++ b/earn/src/components/markets/supply/SupplyTable.tsx
@@ -20,6 +20,7 @@ import { useAccount } from 'wagmi';
 import { ReactComponent as InfoIcon } from '../../../assets/svg/info.svg';
 import { ApyWithTooltip } from '../../common/ApyWithTooltip';
 import { TokenIconsWithTooltip } from '../../common/TokenIconsWithTooltip';
+import RecoverModal, { ALOE_II_BAD_DEBT_LENDERS } from '../modal/RecoverModal';
 import SupplyModal from '../modal/SupplyModal';
 import WithdrawModal from '../modal/WithdrawModal';
 // import OptimizeButton from './OptimizeButton';
@@ -110,6 +111,7 @@ export type SupplyTableRow = {
   suppliedBalanceUsd?: number;
   suppliableBalance: number;
   suppliableBalanceUsd?: number;
+  withdrawableBalance: number;
   isOptimized: boolean;
 };
 
@@ -123,8 +125,10 @@ export default function SupplyTable(props: SupplyTableProps) {
   const { hasAuxiliaryFunds, rows, setPendingTxn } = props;
   const activeChain = useChain();
   const [currentPage, setCurrentPage] = useState(1);
-  const [selectedSupply, setSelectedSupply] = useState<SupplyTableRow | null>(null);
-  const [selectedWithdraw, setSelectedWithdraw] = useState<SupplyTableRow | null>(null);
+  const [selectedRow, setSelectedRow] = useState<{
+    row: SupplyTableRow;
+    action: 'supply' | 'withdraw' | 'recover';
+  } | null>(null);
   const { sortedRows, requestSort, sortConfig } = useSortableData(rows, {
     primaryKey: 'suppliedBalanceUsd',
     secondaryKey: 'totalSupplyUsd',
@@ -280,7 +284,7 @@ export default function SupplyTable(props: SupplyTableProps) {
                     <FilledGreyButton
                       size='S'
                       onClick={() => {
-                        if (userAddress) setSelectedSupply(row);
+                        if (userAddress) setSelectedRow({ row, action: 'supply' });
                       }}
                       disabled={
                         (userAddress &&
@@ -308,7 +312,10 @@ export default function SupplyTable(props: SupplyTableProps) {
                     <FilledGreyButton
                       size='S'
                       onClick={() => {
-                        setSelectedWithdraw(row);
+                        const hasBadDebt =
+                          row.suppliedBalance > row.withdrawableBalance &&
+                          ALOE_II_BAD_DEBT_LENDERS[activeChain.id].includes(row.kitty.address.toLowerCase());
+                        setSelectedRow({ row, action: hasBadDebt ? 'recover' : 'withdraw' });
                       }}
                       disabled={row.suppliedBalance === 0}
                     >
@@ -342,25 +349,30 @@ export default function SupplyTable(props: SupplyTableProps) {
           </tfoot>
         </Table>
       </TableContainer>
-      {selectedSupply && (
+      {selectedRow?.action === 'supply' && (
         <SupplyModal
           hasAuxiliaryFunds={hasAuxiliaryFunds}
           isOpen={true}
-          selectedRow={selectedSupply}
-          setIsOpen={() => {
-            setSelectedSupply(null);
-          }}
+          selectedRow={selectedRow.row}
+          setIsOpen={() => setSelectedRow(null)}
           setPendingTxn={setPendingTxn}
         />
       )}
-      {userAddress && selectedWithdraw && (
+      {userAddress && selectedRow?.action === 'withdraw' && (
         <WithdrawModal
           isOpen={true}
-          selectedRow={selectedWithdraw}
+          selectedRow={selectedRow.row}
           userAddress={userAddress}
-          setIsOpen={() => {
-            setSelectedWithdraw(null);
-          }}
+          setIsOpen={() => setSelectedRow(null)}
+          setPendingTxn={setPendingTxn}
+        />
+      )}
+      {userAddress && selectedRow?.action === 'recover' && (
+        <RecoverModal
+          isOpen={true}
+          selectedRow={selectedRow.row}
+          userAddress={userAddress}
+          setIsOpen={() => setSelectedRow(null)}
           setPendingTxn={setPendingTxn}
         />
       )}

--- a/earn/src/pages/MarketsPage.tsx
+++ b/earn/src/pages/MarketsPage.tsx
@@ -211,6 +211,7 @@ export default function MarketsPage() {
           totalSupply: pair.kitty0Info.totalAssets.toNumber(),
           suppliedBalance: kitty0Balance,
           suppliableBalance: token0Balance,
+          withdrawableBalance: pair.kitty0Info.availableAssets.toNumber(),
           isOptimized: true,
           ...(token0Price > 0
             ? {
@@ -231,6 +232,7 @@ export default function MarketsPage() {
           totalSupply: pair.kitty1Info.totalAssets.toNumber(),
           suppliedBalance: kitty1Balance,
           suppliableBalance: token1Balance,
+          withdrawableBalance: pair.kitty1Info.availableAssets.toNumber(),
           isOptimized: true,
           ...(token1Price > 0
             ? {

--- a/shared/src/abis/BadDebtProcessor.ts
+++ b/shared/src/abis/BadDebtProcessor.ts
@@ -1,0 +1,99 @@
+export const badDebtProcessorAbi = [
+  { type: 'receive', stateMutability: 'payable' },
+  {
+    type: 'function',
+    name: 'callback',
+    inputs: [
+      { name: '', type: 'bytes', internalType: 'bytes' },
+      { name: '', type: 'address', internalType: 'address' },
+      {
+        name: 'amounts',
+        type: 'tuple',
+        internalType: 'struct AuctionAmounts',
+        components: [
+          { name: 'out0', type: 'uint256', internalType: 'uint256' },
+          { name: 'out1', type: 'uint256', internalType: 'uint256' },
+          { name: 'repay0', type: 'uint256', internalType: 'uint256' },
+          { name: 'repay1', type: 'uint256', internalType: 'uint256' },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'process',
+    inputs: [
+      {
+        name: 'lender',
+        type: 'address',
+        internalType: 'contract Lender',
+      },
+      {
+        name: 'borrower',
+        type: 'address',
+        internalType: 'contract Borrower',
+      },
+      {
+        name: 'flashPool',
+        type: 'address',
+        internalType: 'contract IUniswapV3Pool',
+      },
+      { name: 'slippage', type: 'uint256', internalType: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'processWithPermit',
+    inputs: [
+      {
+        name: 'lender',
+        type: 'address',
+        internalType: 'contract Lender',
+      },
+      {
+        name: 'borrower',
+        type: 'address',
+        internalType: 'contract Borrower',
+      },
+      {
+        name: 'flashPool',
+        type: 'address',
+        internalType: 'contract IUniswapV3Pool',
+      },
+      { name: 'slippage', type: 'uint256', internalType: 'uint256' },
+      { name: 'allowance', type: 'uint256', internalType: 'uint256' },
+      { name: 'deadline', type: 'uint256', internalType: 'uint256' },
+      { name: 'v', type: 'uint8', internalType: 'uint8' },
+      { name: 'r', type: 'bytes32', internalType: 'bytes32' },
+      { name: 's', type: 'bytes32', internalType: 'bytes32' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'uniswapV3FlashCallback',
+    inputs: [
+      { name: 'fee0', type: 'uint256', internalType: 'uint256' },
+      { name: 'fee1', type: 'uint256', internalType: 'uint256' },
+      { name: 'data', type: 'bytes', internalType: 'bytes' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'uniswapV3SwapCallback',
+    inputs: [
+      { name: 'amount0Delta', type: 'int256', internalType: 'int256' },
+      { name: 'amount1Delta', type: 'int256', internalType: 'int256' },
+      { name: '', type: 'bytes', internalType: 'bytes' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const;


### PR DESCRIPTION
Frontend feature to accompany [this new contract](https://github.com/aloelabs/aloe-ii-examples/blob/606482cf4f227c6b27d8383b5fcac1be65c933b4/src/BadDebtProcessor.sol)

Uses a flash swap to liquidate enough of the bad debt for the user to withdraw. A portion of the withdrawn funds are then used to repay the flash swap (implying a loss -- it is bad debt after all). The user is left with some combination of the original token (WETH) and the unhealthy borrower's collateral (BASED).

Uses Permit with a finite amount because the contract's callback method is unprotected, and could otherwise be manipulated to enable unchecked spending. In other words, **nobody should `approve` the `BadDebtProcessor` non-atomically, and never for infinite spend.**