### PR TITLE
Fixing undefined includes

### DIFF
--- a/earn/src/components/markets/supply/SupplyTable.tsx
+++ b/earn/src/components/markets/supply/SupplyTable.tsx
@@ -315,7 +315,7 @@ export default function SupplyTable(props: SupplyTableProps) {
                       onClick={() => {
                         const hasBadDebt =
                           row.suppliedBalance > row.withdrawableBalance &&
-                          ALOE_II_BAD_DEBT_LENDERS[activeChain.id].includes(row.kitty.address.toLowerCase());
+                          ALOE_II_BAD_DEBT_LENDERS[activeChain.id]?.includes(row.kitty.address.toLowerCase());
                         setSelectedRow({ row, action: hasBadDebt ? 'recover' : 'withdraw' });
                       }}
                       disabled={row.suppliedBalance === 0}


### PR DESCRIPTION
Fixing a bug where we try to check if the bad debt lenders includes a certain asset, even if there is no bad debt on that chain. To fix this, I added optional chaining to prevent this from crashing in the case where the selected chain doesn't have any pairs with bad debt and `row.suppliedBalance > row.withdrawableBalance` (which is when the bug occurs).