### PR TITLE
Fixing withdraw modal updates and adding info

### DIFF
--- a/earn/src/components/markets/supply/SupplyTable.tsx
+++ b/earn/src/components/markets/supply/SupplyTable.tsx
@@ -315,7 +315,7 @@ export default function SupplyTable(props: SupplyTableProps) {
                       onClick={() => {
                         const hasBadDebt =
                           row.suppliedBalance > row.withdrawableBalance &&
-                          ALOE_II_BAD_DEBT_LENDERS[activeChain.id].includes(row.kitty.address.toLowerCase());
+                          ALOE_II_BAD_DEBT_LENDERS[activeChain.id]?.includes(row.kitty.address.toLowerCase());
                         setSelectedRow({ row, action: hasBadDebt ? 'recover' : 'withdraw' });
                       }}
                       disabled={row.suppliedBalance === 0}


### PR DESCRIPTION
Removed refetching for balance result data as it would often conflict with the max withdrawable data which would make things complicated. I chose to remove it rather than try to make it work as a constantly flowing stream of data makes keeping the form up to date while not messing with the user's input very complex. Moreover, I find it annoying when my balances are constantly changing, especially when trying to withdraw everything. I know there are some workaround we could try, but unless there are clear drawbacks to this approach, I feel it would be better to keep it simple. Additionally, I added a callout if the user is limited in how much they can withdraw due to utilization. To determine if the user is limited, I took a similar approach to the isConstrainedByUtilization by checking the withdrawablePercentage.
<img width="474" alt="image" src="https://github.com/user-attachments/assets/d9d8a287-eb9e-47cf-9d5f-eb6171dc221b">
